### PR TITLE
bump acceptance test go version to 1.16.7 to match enterprise dockerfile

### DIFF
--- a/.github/workflows/acceptance-test.yaml
+++ b/.github/workflows/acceptance-test.yaml
@@ -10,7 +10,7 @@ on:
       - v*
 
 env:
-  GO_VERSION: "1.15.7"
+  GO_VERSION: "1.16.7"
 
 jobs:
   Build-Snapshot-Artifacts:


### PR DESCRIPTION
Signed-off-by: Vijay Pillai <vijay.pillai@anchore.com>