### PR TITLE
bump release workflow go version to 1.16.7 to match enterprise

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ on:
       - 'v*'
 
 env:
-  GO_VERSION: "1.15.7"
+  GO_VERSION: "1.16.7"
 
 jobs:
   wait-for-checks:


### PR DESCRIPTION
Related: https://github.com/anchore/kai/pull/36
Signed-off-by: Vijay Pillai <vijay.pillai@anchore.com>