### PR TITLE
bump minimum go version in go.mod to go v1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anchore/kai
 
-go 1.14
+go 1.16
 
 require (
 	github.com/adrg/xdg v0.2.1


### PR DESCRIPTION
Signed-off-by: Vijay Pillai <vijay.pillai@anchore.com>