### PR TITLE
Add support for building kai against boringcrypto go (FIPS)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,11 @@ linux-binary: clean bootstrap
 	mkdir -p $(SNAPSHOTDIR)
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o $(SNAPSHOTDIR)/kai .
 
+.PHONY: linux-binary-fips
+linux-binary-fips: clean bootstrap
+	mkdir -p $(SNAPSHOTDIR)
+	CGO_ENABLED=1 GOOS=linux GOARCH=amd64 GOEXPERIMENT=boringcrypto go build -a -installsuffix cgo -o $(SNAPSHOTDIR)/kai .
+
 .PHONY: linux-binary-arm64
 linux-binary-arm64: clean bootstrap
 	mkdir -p $(SNAPSHOTDIR)
@@ -167,6 +172,11 @@ linux-binary-arm64: clean bootstrap
 mac-binary: clean bootstrap
 	mkdir -p $(SNAPSHOTDIR)
 	CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -a -installsuffix cgo -o $(SNAPSHOTDIR)/kai .
+
+.PHONY: mac-binary-fips
+mac-binary-fips: clean bootstrap
+	mkdir -p $(SNAPSHOTDIR)
+	CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 GOEXPERIMENT=boringcrypto go build -a -installsuffix cgo -o $(SNAPSHOTDIR)/kai .
 
 .PHONY: mac-binary-arm64
 mac-binary-arm64: clean bootstrap

--- a/README.md
+++ b/README.md
@@ -429,13 +429,27 @@ in favor of `namespace-selectors`
 **Note:** This will drop the binary in the `./snapshot/` directory
 
 **On Mac**
+
 ```sh
 make mac-binary
 ```
 
+To use FIPS boringcrypto:
+
+```sh
+make mac-binary-fips
+```
+
 **On Linux**
+
 ```sh
 make linux-binary
+```
+
+To use FIPS boringcrypto:
+
+```sh
+make linux-binary-fips
 ```
 
 ### Testing


### PR DESCRIPTION
## Summary
Kai is not currently currently compiled against boringcrypto Go. This is required for environments where FIPS validated crypto is required. For Go applications, it isn't enough to just drop Kai onto a FIPS enabled host with FIPS openssl, it needs to be compiled against boringcrypto Go.

Since Go v1.19, this is pretty easy to do, by specifying an additional argument. Go versions prior to v1.19 requires one of different processes. However it looks like the Kai CI pipeline (gh actions), where recently set to use v.1.9.

## Testing
You can leverage [goversion](https://github.com/rsc/goversion) as a quick means to see which version of Go a binary is compiled against.

After making these changes, I built a container image with the binary, and deployed it to a FIPS enabled host. I was able to validate via:

```bash
goversion -crypto /usr/bin/kai
/usr/bin/kai go1.19.4 X:boringcrypto (boring crypto)
```

Note the last piece of the command is important '(boring crypto)'. If you are running the same check on a non-FIPS enabled host, or an application not built against Go with the flag set, you may see:

```bash
goversion -crypto ./snapshot/kai
./snapshot/kai go1.19.5 X:boringcrypto (standard crypto)
```

At first glance you may see 'boringcrypto' but the last part - 'standard crypto' indicates it's not compliant. 