### PR TITLE
feat: make additional metadata optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,9 @@ kubeconfig:
 
 # enable/disable printing inventory reports to stdout
 verbose-inventory-reports: false
+
+# collect additional metadata about where a container is running (e.g. namespace labels, namespace annotations, etc.) [defaults to true]
+metadata: true
 ```
 
 ### Namespace selection

--- a/anchore-k8s-inventory.yaml
+++ b/anchore-k8s-inventory.yaml
@@ -79,8 +79,8 @@ ignore-not-running: true
 polling-interval-seconds: 300
 
 anchore:
-#  url:
-#  user: admin
+  # url: $ANCHORE_K8S_INVENTORY_ANCHORE_URL
+  # user: $ANCHORE_K8S_INVENTORY_ANCHORE_USER
   password: $ANCHORE_K8S_INVENTORY_ANCHORE_PASSWORD
 #  http:
 #    insecure: true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,8 +7,7 @@ are listed below in order of precedence:
   - ~/.kai.yaml
   - <XDG_CONFIG_HOME>/kai/config.yaml
   - Environment Variables prefixed with KAI_
-*/
-package config
+*/package config
 
 import (
 	"fmt"
@@ -54,6 +53,7 @@ type Application struct {
 	PollingIntervalSeconds          int         `mapstructure:"polling-interval-seconds"`
 	AnchoreDetails                  AnchoreInfo `mapstructure:"anchore"`
 	VerboseInventoryReports         bool        `mapstructure:"verbose-inventory-reports"`
+	Metadata                        bool        `mapstructure:"metadata"` // if true, include runtime metadata in the inventory report
 }
 
 // MissingTagConf details the policy for handling missing tags when reporting images
@@ -129,6 +129,7 @@ func setNonCliDefaultValues(v *viper.Viper) {
 	v.SetDefault("namespaces", []string{})
 	v.SetDefault("namespace-selectors.include", []string{})
 	v.SetDefault("namespace-selectors.exclude", []string{})
+	v.SetDefault("metadata", true)
 }
 
 // Load the Application Configuration from the Viper specifications

--- a/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
@@ -46,3 +46,4 @@ anchoredetails:
     insecure: false
     timeoutseconds: 10
 verboseinventoryreports: false
+metadata: true

--- a/internal/config/test-fixtures/snapshot/TestEmptyConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestEmptyConfigString.golden
@@ -46,3 +46,4 @@ anchoredetails:
     insecure: false
     timeoutseconds: 0
 verboseinventoryreports: false
+metadata: false

--- a/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
@@ -46,3 +46,4 @@ anchoredetails:
     insecure: false
     timeoutseconds: 10
 verboseinventoryreports: false
+metadata: true

--- a/pkg/inventory/namespace.go
+++ b/pkg/inventory/namespace.go
@@ -71,7 +71,12 @@ func excludeNamespace(checks []excludeCheck, namespace string) bool {
 	return false
 }
 
-func FetchNamespaces(c client.Client, batchSize, timeout int64, excludes, includes []string) ([]Namespace, error) {
+func FetchNamespaces(
+	c client.Client,
+	batchSize, timeout int64,
+	excludes, includes []string,
+	metadata bool,
+) ([]Namespace, error) {
 	defer tracker.TrackFunctionTime(time.Now(), "Fetching namespaces")
 	nsMap := make(map[string]Namespace)
 
@@ -91,11 +96,18 @@ func FetchNamespaces(c client.Client, batchSize, timeout int64, excludes, includ
 		}
 		for _, n := range list.Items {
 			if !excludeNamespace(exclusionChecklist, n.ObjectMeta.Name) {
-				nsMap[n.ObjectMeta.Name] = Namespace{
-					Name:        n.ObjectMeta.Name,
-					UID:         string(n.UID),
-					Annotations: n.Annotations,
-					Labels:      n.Labels,
+				if metadata {
+					nsMap[n.ObjectMeta.Name] = Namespace{
+						Name:        n.ObjectMeta.Name,
+						UID:         string(n.UID),
+						Annotations: n.Annotations,
+						Labels:      n.Labels,
+					}
+				} else {
+					nsMap[n.ObjectMeta.Name] = Namespace{
+						Name: n.ObjectMeta.Name,
+						UID:  string(n.UID),
+					}
 				}
 			}
 		}

--- a/pkg/inventory/pods.go
+++ b/pkg/inventory/pods.go
@@ -40,18 +40,26 @@ func FetchPodsInNamespace(c client.Client, batchSize, timeout int64, namespace s
 	return podList, nil
 }
 
-func ProcessPods(pods []v1.Pod, namespaceUID string) []Pod {
+func ProcessPods(pods []v1.Pod, namespaceUID string, metadata bool) []Pod {
 	var podList []Pod
 
 	for _, p := range pods {
-		podList = append(podList, Pod{
-			Name:         p.ObjectMeta.Name,
-			UID:          string(p.UID),
-			Annotations:  p.Annotations,
-			Labels:       p.Labels,
-			NamespaceUID: namespaceUID,
-			// TODO NodeUID
-		})
+		if metadata {
+			podList = append(podList, Pod{
+				Name:         p.ObjectMeta.Name,
+				UID:          string(p.UID),
+				Annotations:  p.Annotations,
+				Labels:       p.Labels,
+				NamespaceUID: namespaceUID,
+				// TODO NodeUID
+			})
+		} else {
+			podList = append(podList, Pod{
+				Name:         p.ObjectMeta.Name,
+				UID:          string(p.UID),
+				NamespaceUID: namespaceUID,
+			})
+		}
 	}
 
 	return podList

--- a/pkg/inventory/pods_test.go
+++ b/pkg/inventory/pods_test.go
@@ -75,6 +75,7 @@ func TestProcessPods(t *testing.T) {
 	type args struct {
 		pods         []v1.Pod
 		namespaceUID string
+		metadata     bool
 	}
 	tests := []struct {
 		name string
@@ -100,6 +101,7 @@ func TestProcessPods(t *testing.T) {
 					},
 				},
 				namespaceUID: "namespace-uid-0000",
+				metadata:     true,
 			},
 			want: []Pod{
 				{
@@ -115,10 +117,39 @@ func TestProcessPods(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "only return minimal metadata",
+			args: args{
+				pods: []v1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-pod",
+							UID:  "test-uid",
+							Annotations: map[string]string{
+								"test-annotation": "test-value",
+							},
+							Labels: map[string]string{
+								"test-label": "test-value",
+							},
+							Namespace: "test-namespace",
+						},
+					},
+				},
+				namespaceUID: "namespace-uid-0000",
+				metadata:     false,
+			},
+			want: []Pod{
+				{
+					Name:         "test-pod",
+					UID:          "test-uid",
+					NamespaceUID: "namespace-uid-0000",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ProcessPods(tt.args.pods, tt.args.namespaceUID)
+			got := ProcessPods(tt.args.pods, tt.args.namespaceUID, tt.args.metadata)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/lib.go
+++ b/pkg/lib.go
@@ -132,7 +132,7 @@ func GetInventoryReport(cfg *config.Application) (inventory.Report, error) {
 
 	namespaces, err := inventory.FetchNamespaces(client,
 		cfg.Kubernetes.RequestBatchSize, cfg.Kubernetes.RequestTimeoutSeconds,
-		cfg.NamespaceSelectors.Exclude, cfg.NamespaceSelectors.Include)
+		cfg.NamespaceSelectors.Exclude, cfg.NamespaceSelectors.Include, cfg.Metadata)
 	if err != nil {
 		return inventory.Report{}, err
 	}
@@ -193,7 +193,7 @@ func processNamespace(clientset *kubernetes.Clientset, cfg *config.Application, 
 		return
 	}
 
-	pods := inventory.ProcessPods(v1pods, ns.UID)
+	pods := inventory.ProcessPods(v1pods, ns.UID, cfg.Metadata)
 	containers := inventory.GetContainersFromPods(
 		v1pods,
 		cfg.IgnoreNotRunning,


### PR DESCRIPTION
if metadata = false in the config, then labels/annotations/other
metadata that is not required by the API will be omitted. This could be
useful to restrict the number of k8s API calls in the future and keep
the payload to Anchore enterprise smaller if required.

Signed-off-by: Bradley Jones <bradley.jones@anchore.com>
