### PR TITLE
Check API version to determine correct Report API endpoint for V1/V2

### DIFF
--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -6,8 +6,10 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 
 	"github.com/anchore/k8s-inventory/internal/config"
@@ -16,7 +18,10 @@ import (
 	"github.com/anchore/k8s-inventory/pkg/inventory"
 )
 
-const ReportAPIPath = "v1/enterprise/kubernetes-inventory"
+const ReportAPIPathV1 = "v1/enterprise/kubernetes-inventory"
+const ReportAPIPathV2 = "v2/kubernetes-inventory"
+
+var Version = 0
 
 // This method does the actual Reporting (via HTTP) to Anchore
 //
@@ -61,13 +66,64 @@ func Post(report inventory.Report, anchoreDetails config.AnchoreInfo) error {
 	return nil
 }
 
+type anchoreVersion struct {
+	Api struct {
+		Version string `json:"version"`
+	} `json:"api"`
+}
+
+// This method retrieves the API version from Anchore
+//
+//nolint:gosec
+func getVersion(anchoreDetails config.AnchoreInfo) (int, error) {
+	log.Debug("Detecting Anchore API version")
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: anchoreDetails.HTTP.Insecure},
+	}
+	client := &http.Client{
+		Transport: tr,
+		Timeout:   time.Duration(anchoreDetails.HTTP.TimeoutSeconds) * time.Second,
+	}
+	resp, err := client.Get(anchoreDetails.URL + "/version")
+	if err != nil {
+		return 0, fmt.Errorf("failed to request API version: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return 0, fmt.Errorf("failed to retrieve API version: %+v", resp)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read API version: %w", err)
+	}
+
+	ver := anchoreVersion{}
+	err = json.Unmarshal(body, &ver)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse API version: %w", err)
+	}
+
+	return strconv.Atoi(ver.Api.Version)
+}
+
 func buildURL(anchoreDetails config.AnchoreInfo) (string, error) {
 	anchoreURL, err := url.Parse(anchoreDetails.URL)
 	if err != nil {
 		return "", err
 	}
 
-	anchoreURL.Path += ReportAPIPath
+	if Version == 0 {
+		Version, err = getVersion(anchoreDetails)
+		if err != nil {
+			return "", fmt.Errorf("failed to retrieve API version: %w", err)
+		}
+	}
+
+	if Version == 1 {
+		anchoreURL.Path += ReportAPIPathV1
+	} else {
+		anchoreURL.Path += ReportAPIPathV2
+	}
 
 	return anchoreURL.String(), nil
 }

--- a/pkg/reporter/reporter_test.go
+++ b/pkg/reporter/reporter_test.go
@@ -13,8 +13,16 @@ func TestBuildUrl(t *testing.T) {
 		Password: "foobar",
 	}
 
+	Version = 1
 	expectedURL := "https://ancho.re/v1/enterprise/kubernetes-inventory"
 	actualURL, err := buildURL(anchoreDetails)
+	if err != nil || expectedURL != actualURL {
+		t.Errorf("Failed to build URL:\nexpected=%s\nactual=%s", expectedURL, actualURL)
+	}
+
+	Version = 2
+	expectedURL = "https://ancho.re/v2/kubernetes-inventory"
+	actualURL, err = buildURL(anchoreDetails)
 	if err != nil || expectedURL != actualURL {
 		t.Errorf("Failed to build URL:\nexpected=%s\nactual=%s", expectedURL, actualURL)
 	}


### PR DESCRIPTION
This will query the /version first, parse the response, and change the POST URL as needed based on the detected version.

Interesting to note that requesting /version does not require authentication, and the "version" is returned as a JSON string not an integer from the API:

```
$ curl http://localhost:8228/version
{"api": {"version": "2"}, "db": {"schema_version": "500"}, "service": {"version": "5.0.0"}}

```