### PR TITLE
fix: try to catch invalid responses on Enterprise API redirect

### DIFF
--- a/pkg/reporter/reporter_test.go
+++ b/pkg/reporter/reporter_test.go
@@ -96,6 +96,24 @@ func TestPost(t *testing.T) {
 			wantErr:         true,
 			expectedAPIPath: reportAPIPathV1,
 		},
+		{
+			name: "error when api response is not JSON",
+			args: args{
+				report: inventory.Report{},
+				anchoreDetails: config.AnchoreInfo{
+					URL:      "https://ancho.re",
+					User:     "admin",
+					Password: "foobar",
+					Account:  "test",
+					HTTP: config.HTTPConfig{
+						TimeoutSeconds: 10,
+						Insecure:       true,
+					},
+				},
+			},
+			wantErr:         true,
+			expectedAPIPath: reportAPIPathV2,
+		},
 	}
 	for _, tt := range tests {
 		switch tt.name {
@@ -127,6 +145,11 @@ func TestPost(t *testing.T) {
 			gock.New("https://ancho.re").
 				Get("/version").
 				Reply(404)
+		case "error when api response is not JSON":
+			gock.New("https://ancho.re").
+				Post(reportAPIPathV2).
+				Reply(200).
+				BodyString("not json")
 		}
 
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/reporter/reporter_test.go
+++ b/pkg/reporter/reporter_test.go
@@ -102,14 +102,16 @@ func TestPost(t *testing.T) {
 		case "default post to v2":
 			gock.New("https://ancho.re").
 				Post(reportAPIPathV2).
-				Reply(200)
+				Reply(200).
+				JSON(map[string]interface{}{})
 		case "post to v1 when v2 is not found":
 			gock.New("https://ancho.re").
 				Post(reportAPIPathV2).
 				Reply(404)
 			gock.New("https://ancho.re").
 				Post(reportAPIPathV1).
-				Reply(200)
+				Reply(200).
+				JSON(map[string]interface{}{})
 			gock.New("https://ancho.re").
 				Get("/version").
 				Reply(200).
@@ -176,7 +178,8 @@ func TestPostSimulateV1ToV2HandoverFromEnterprise4Xto5X(t *testing.T) {
 		})
 	gock.New("https://ancho.re").
 		Post(reportAPIPathV1).
-		Reply(200)
+		Reply(200).
+		JSON(map[string]interface{}{})
 	err := Post(testReport, testAnchoreDetails)
 	assert.NoError(t, err)
 	assert.Equal(t, reportAPIPathV1, enterpriseEndpoint)
@@ -195,7 +198,8 @@ func TestPostSimulateV1ToV2HandoverFromEnterprise4Xto5X(t *testing.T) {
 		})
 	gock.New("https://ancho.re").
 		Post(reportAPIPathV2).
-		Reply(200)
+		Reply(200).
+		JSON(map[string]interface{}{})
 	err = Post(testReport, testAnchoreDetails)
 	assert.NoError(t, err)
 	assert.Equal(t, reportAPIPathV2, enterpriseEndpoint)


### PR DESCRIPTION
Go's http client will automatically follow redirects, we want to preserve the ability to follow redirects but we need to catch cases where the redirect returns a 2XX status but the POST was not actually successful. A simple check is read the response body (if one is present) and check if it is valid JSON. If it is not JSON, as is the case with cloudflare where it redirects to a login screen then we can return an error and log the response body to give customers an indication of where the redirect has taken them so it can be remediated at the proxy