### PR TITLE
test: use 201 responses in UTs to better represent the Enterprise API

### DIFF
--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -128,7 +128,6 @@ func checkVersion(anchoreDetails config.AnchoreInfo) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		fmt.Println("fff")
 		return fmt.Errorf("failed to retrieve Anchore API version: %+v", resp)
 	}
 	body, err := io.ReadAll(resp.Body)

--- a/pkg/reporter/reporter_test.go
+++ b/pkg/reporter/reporter_test.go
@@ -120,7 +120,7 @@ func TestPost(t *testing.T) {
 		case "default post to v2":
 			gock.New("https://ancho.re").
 				Post(reportAPIPathV2).
-				Reply(200).
+				Reply(201).
 				JSON(map[string]interface{}{})
 		case "post to v1 when v2 is not found":
 			gock.New("https://ancho.re").
@@ -128,7 +128,7 @@ func TestPost(t *testing.T) {
 				Reply(404)
 			gock.New("https://ancho.re").
 				Post(reportAPIPathV1).
-				Reply(200).
+				Reply(201).
 				JSON(map[string]interface{}{})
 			gock.New("https://ancho.re").
 				Get("/version").
@@ -148,7 +148,7 @@ func TestPost(t *testing.T) {
 		case "error when api response is not JSON":
 			gock.New("https://ancho.re").
 				Post(reportAPIPathV2).
-				Reply(200).
+				Reply(201).
 				BodyString("not json")
 		}
 
@@ -201,7 +201,7 @@ func TestPostSimulateV1ToV2HandoverFromEnterprise4Xto5X(t *testing.T) {
 		})
 	gock.New("https://ancho.re").
 		Post(reportAPIPathV1).
-		Reply(200).
+		Reply(201).
 		JSON(map[string]interface{}{})
 	err := Post(testReport, testAnchoreDetails)
 	assert.NoError(t, err)
@@ -221,7 +221,7 @@ func TestPostSimulateV1ToV2HandoverFromEnterprise4Xto5X(t *testing.T) {
 		})
 	gock.New("https://ancho.re").
 		Post(reportAPIPathV2).
-		Reply(200).
+		Reply(201).
 		JSON(map[string]interface{}{})
 	err = Post(testReport, testAnchoreDetails)
 	assert.NoError(t, err)


### PR DESCRIPTION
- fix: remove unnecessary println
- test: change reporter tests to use respond with 201
