### PR TITLE
Update README.md to fix chart link to correct branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ helm repo add anchore https://charts.anchore.io
 helm install <release-name> -f <values.yaml> anchore/anchore-k8s-inventory
 ```
 
-A basic values file can always be found [here](https://github.com/anchore/anchore-charts/tree/master/stable/anchore-k8s-inventory/values.yaml)
+A basic values file can always be found [here](https://github.com/anchore/anchore-charts/tree/main/stable/k8s-inventory/values.yaml)
 
 ## Configuration
 ```yaml


### PR DESCRIPTION
Fixes 'master' to 'main' as used in the chart repo. Fixes a broken link for the values yaml.