### PR TITLE
feat: change docker image to scratch container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static-debian11:debug@sha256:a0a404776dec98be120089ae42bbdfbe48c177921d856937d124d48eb8c0b951 AS build
 
-COPY anchore-k8s-inventory /usr/bin
+FROM scratch
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
-USER nonroot:nobody
+WORKDIR /tmp
+
+COPY anchore-k8s-inventory /
 
 ARG BUILD_DATE
 ARG BUILD_VERSION
@@ -18,4 +21,4 @@ LABEL org.opencontainers.image.vendor="Anchore, Inc."
 LABEL org.opencontainers.image.version=$BUILD_VERSION
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
-ENTRYPOINT ["anchore-k8s-inventory"]
+ENTRYPOINT ["/anchore-k8s-inventory"]

--- a/Dockerfile.skaffold
+++ b/Dockerfile.skaffold
@@ -1,8 +1,11 @@
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static-debian11:debug@sha256:a0a404776dec98be120089ae42bbdfbe48c177921d856937d124d48eb8c0b951 AS build
 
-COPY snapshot/kai /usr/bin
+FROM scratch
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
-USER nonroot:nobody
+WORKDIR /tmp
+
+COPY snapshot/anchore-k8s-inventory /
 
 ARG BUILD_DATE
 ARG BUILD_VERSION
@@ -18,4 +21,4 @@ LABEL org.opencontainers.image.vendor="Anchore, Inc."
 LABEL org.opencontainers.image.version=$BUILD_VERSION
 LABEL org.opencontainers.image.licenses="Apache-2.0"
 
-ENTRYPOINT ["kai"]
+ENTRYPOINT ["/anchore-k8s-inventory"]

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,23 +1,29 @@
-apiVersion: skaffold/v4beta2
+apiVersion: skaffold/v3
 kind: Config
 metadata:
-  name: kai
+  name: k8s-inventory
 build:
   artifacts:
-  - image: local/kai
+  - image: local/k8sinv
     docker:
       dockerfile: Dockerfile.skaffold
+  local:
+    push: false
 deploy:
   helm:
     releases:
-    - name: kai
-      chartPath: anchore-charts/stable/kai
+    - name: k8s-inventory-dev
+      chartPath: anchore-charts/stable/k8s-inventory
       setValueTemplates:
-        image.repository: "{{.IMAGE_REPO_local_kai}}"
-        image.tag: "{{.IMAGE_TAG_local_kai}}"
+        image.repository: "{{.IMAGE_REPO_local_k8sinv}}"
+        image.tag: "{{.IMAGE_TAG}}"
       setValues:
-        kai.log.level: debug
-        kai.log.structured: false
-        kai.quiet: false
-        kai.verboseInventoryReports: false
-        kai.pollingIntervalSeconds: 60
+        k8sInventory.log.level: debug
+        k8sInventory.log.structured: false
+        k8sInventory.quiet: false
+        k8sInventory.verboseInventoryReports: true
+        k8sInventory.pollingIntervalSeconds: 60
+        k8sInventory.anchore.url: "http://host.docker.internal:8228"
+        k8sInventory.anchore.user: "admin"
+        k8sInventory.anchore.password: "foobar"
+        k8sInventory.anchore.http.insecure: true


### PR DESCRIPTION
- feat: change base image to scratch container
- chore: fix skaffold build for dev

Changing to a scratch container that just pulls in the SSL certs from the
debian distroless image to reduce the vuln surface in the image.
