### PR TITLE
fix: ensure that inventory report is logged on post error

### DIFF
--- a/pkg/lib.go
+++ b/pkg/lib.go
@@ -44,6 +44,13 @@ func reportToStdout(report inventory.Report) error {
 }
 
 func HandleReport(report inventory.Report, cfg *config.Application) error {
+	if cfg.VerboseInventoryReports {
+		err := reportToStdout(report)
+		if err != nil {
+			log.Errorf("Failed to output Inventory Report: %w", err)
+		}
+	}
+
 	if cfg.AnchoreDetails.IsValid() {
 		if err := reporter.Post(report, cfg.AnchoreDetails); err != nil {
 			return fmt.Errorf("unable to report Inventory to Anchore: %w", err)
@@ -51,10 +58,6 @@ func HandleReport(report inventory.Report, cfg *config.Application) error {
 		log.Info("Inventory report sent to Anchore")
 	} else {
 		log.Info("Anchore details not specified, not reporting inventory")
-	}
-
-	if cfg.VerboseInventoryReports {
-		return reportToStdout(report)
 	}
 	return nil
 }


### PR DESCRIPTION
If verbose-inventory-reports is set to true, to aid debugging we should log the report to
stdout even in the case of an error from Enterprise during the post.

Signed-off-by: Bradley Jones <bradley.jones@anchore.com>
