### PR TITLE
Revert "feat: change default http timeout from 10 to 60 seconds"

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ anchore:
   password: $ANCHORE_K8S_INVENTORY_ANCHORE_PASSWORD
   http:
     insecure: true
-    timeout-seconds: 60
+    timeout-seconds: 10
 ```
 
 ## Behavior change (v0.5.0) (formerly KAI) 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -117,7 +117,7 @@ func setNonCliDefaultValues(v *viper.Viper) {
 	v.SetDefault("anchore.account", "admin")
 	v.SetDefault("kubeconfig.anchore.account", "admin")
 	v.SetDefault("anchore.http.insecure", false)
-	v.SetDefault("anchore.http.timeout-seconds", 60)
+	v.SetDefault("anchore.http.timeout-seconds", 10)
 	v.SetDefault("kubernetes-request-timeout-seconds", -1)
 	v.SetDefault("kubernetes.request-timeout-seconds", 60)
 	v.SetDefault("kubernetes.request-batch-size", 100)

--- a/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
@@ -44,5 +44,5 @@ anchoredetails:
   account: admin
   http:
     insecure: false
-    timeoutseconds: 60
+    timeoutseconds: 10
 verboseinventoryreports: false

--- a/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
@@ -44,5 +44,5 @@ anchoredetails:
   account: admin
   http:
     insecure: false
-    timeoutseconds: 60
+    timeoutseconds: 10
 verboseinventoryreports: false


### PR DESCRIPTION
Reverts anchore/k8s-inventory#164 until the next major version bump as this will be a breaking change for users