### PR TITLE
feat: add option to ignore empty namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,9 @@ namespace-selectors:
   #
   # Will exclude the default, kube-system, and kube-public namespaces
   exclude: []
+
+  # If true then namespaces containing 0 pods will be omitted from the report sent to Anchore Enterprise
+  ignore-empty: false
 ```
 
 ### Kubernetes API Parameters

--- a/anchore-k8s-inventory.yaml
+++ b/anchore-k8s-inventory.yaml
@@ -41,6 +41,8 @@ namespace-selectors:
   # Will exclude the default, kube-system, and kube-public namespaces
   exclude: []
 
+  ignore-empty: false
+
 # Kubernetes API configuration parameters (should not need tuning)
 kubernetes:
   # Sets the request timeout for kubernetes API requests

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,8 +63,9 @@ type MissingTagConf struct {
 
 // NamespaceSelector details the inclusion/exclusion rules for namespaces
 type NamespaceSelector struct {
-	Include []string `mapstructure:"include"`
-	Exclude []string `mapstructure:"exclude"`
+	Include     []string `mapstructure:"include"`
+	Exclude     []string `mapstructure:"exclude"`
+	IgnoreEmpty bool     `mapstructure:"ignore-empty"`
 }
 
 // KubernetesAPI details the configuration for interacting with the k8s api server
@@ -128,6 +129,7 @@ func setNonCliDefaultValues(v *viper.Viper) {
 	v.SetDefault("namespaces", []string{})
 	v.SetDefault("namespace-selectors.include", []string{})
 	v.SetDefault("namespace-selectors.exclude", []string{})
+	v.SetDefault("namespace-selectors.ignore-empty", false)
 }
 
 // Load the Application Configuration from the Viper specifications

--- a/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
@@ -30,6 +30,7 @@ kubernetesrequesttimeoutseconds: -1
 namespaceselectors:
   include: []
   exclude: []
+  ignoreempty: false
 missingtagpolicy:
   policy: digest
   tag: UNKNOWN

--- a/internal/config/test-fixtures/snapshot/TestEmptyConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestEmptyConfigString.golden
@@ -30,6 +30,7 @@ kubernetesrequesttimeoutseconds: 0
 namespaceselectors:
   include: []
   exclude: []
+  ignoreempty: false
 missingtagpolicy:
   policy: ""
   tag: ""

--- a/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
@@ -30,6 +30,7 @@ kubernetesrequesttimeoutseconds: -1
 namespaceselectors:
   include: []
   exclude: []
+  ignoreempty: false
 missingtagpolicy:
   policy: digest
   tag: UNKNOWN


### PR DESCRIPTION
if `ignore-empty` is true under the namespace-selectors config section
then if the namespace contains no pods then it will not be included in
the report sent to Anchore Enterprise.

Signed-off-by: Bradley Jones <bradley.jones@anchore.com>
