### PR TITLE
feat: add missing registry override

### DIFF
--- a/anchore-k8s-inventory.yaml
+++ b/anchore-k8s-inventory.yaml
@@ -57,6 +57,15 @@ kubernetes:
 # Can be one of adhoc, periodic (defaults to adhoc)
 mode: adhoc
 
+# If no registry information can be found by a `pod describe` you can use this
+# field to override the registry for images where no registry is found. This
+# can happen when the cluster is configured to use a specific private repo.
+# However, kubernetes does not represent this in the pod describe output other
+# than as the default 'docker.io' registry in the Image ID and a blank registry
+# in the Image field. This should be set to match the private registry
+# configuration of the cluster.
+missing-registry-override:  # ex. myregistry.io
+
 # Handle cases where a tag is missing. For example - images designated by digest
 missing-tag-policy:
   # One of the following options [digest, insert, drop]. Default is 'digest'

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,7 @@ type Application struct {
 	Namespaces                      []string          `mapstructure:"namespaces"`
 	KubernetesRequestTimeoutSeconds int64             `mapstructure:"kubernetes-request-timeout-seconds"`
 	NamespaceSelectors              NamespaceSelector `mapstructure:"namespace-selectors"`
+	MissingRegistryOverride         string            `mapstructure:"missing-registry-override"`
 	MissingTagPolicy                MissingTagConf    `mapstructure:"missing-tag-policy"`
 	RunMode                         mode.Mode
 	Mode                            string      `mapstructure:"mode"`
@@ -124,6 +125,7 @@ func setNonCliDefaultValues(v *viper.Viper) {
 	v.SetDefault("kubernetes.request-batch-size", 100)
 	v.SetDefault("kubernetes.worker-pool-size", 100)
 	v.SetDefault("ignore-not-running", true)
+	v.SetDefault("missing-registry-override", "")
 	v.SetDefault("missing-tag-policy.policy", "digest")
 	v.SetDefault("missing-tag-policy.tag", "UNKNOWN")
 	v.SetDefault("namespaces", []string{})

--- a/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
@@ -31,6 +31,7 @@ namespaceselectors:
   include: []
   exclude: []
   ignoreempty: false
+missingregistryoverride: ""
 missingtagpolicy:
   policy: digest
   tag: UNKNOWN

--- a/internal/config/test-fixtures/snapshot/TestEmptyConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestEmptyConfigString.golden
@@ -31,6 +31,7 @@ namespaceselectors:
   include: []
   exclude: []
   ignoreempty: false
+missingregistryoverride: ""
 missingtagpolicy:
   policy: ""
   tag: ""

--- a/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
@@ -31,6 +31,7 @@ namespaceselectors:
   include: []
   exclude: []
   ignoreempty: false
+missingregistryoverride: ""
 missingtagpolicy:
   policy: digest
   tag: UNKNOWN

--- a/pkg/inventory/containers_test.go
+++ b/pkg/inventory/containers_test.go
@@ -9,9 +9,10 @@ import (
 
 func Test_getContainersInPod(t *testing.T) {
 	type args struct {
-		pod              v1.Pod
-		missingTagPolicy string
-		dummyTag         string
+		pod                     v1.Pod
+		missingRegistryOverride string
+		missingTagPolicy        string
+		dummyTag                string
 	}
 	tests := []struct {
 		name string
@@ -41,8 +42,9 @@ func Test_getContainersInPod(t *testing.T) {
 						},
 					},
 				},
-				missingTagPolicy: "digest",
-				dummyTag:         "UNKNOWN",
+				missingRegistryOverride: "",
+				missingTagPolicy:        "digest",
+				dummyTag:                "UNKNOWN",
 			},
 			want: []Container{
 				{
@@ -76,8 +78,9 @@ func Test_getContainersInPod(t *testing.T) {
 						},
 					},
 				},
-				missingTagPolicy: "digest",
-				dummyTag:         "UNKNOWN",
+				missingRegistryOverride: "",
+				missingTagPolicy:        "digest",
+				dummyTag:                "UNKNOWN",
 			},
 			want: []Container{
 				{
@@ -103,8 +106,9 @@ func Test_getContainersInPod(t *testing.T) {
 						},
 					},
 				},
-				missingTagPolicy: "digest",
-				dummyTag:         "UNKNOWN",
+				missingRegistryOverride: "",
+				missingTagPolicy:        "digest",
+				dummyTag:                "UNKNOWN",
 			},
 			want: []Container{
 				{
@@ -118,7 +122,7 @@ func Test_getContainersInPod(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := getContainersInPod(tt.args.pod, tt.args.missingTagPolicy, tt.args.dummyTag)
+			got := getContainersInPod(tt.args.pod, tt.args.missingRegistryOverride, tt.args.missingTagPolicy, tt.args.dummyTag)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -126,10 +130,11 @@ func Test_getContainersInPod(t *testing.T) {
 
 func TestGetContainersFromPods(t *testing.T) {
 	type args struct {
-		pods             []v1.Pod
-		ignoreNotRunning bool
-		missingTagPolicy string
-		dummyTag         string
+		pods                    []v1.Pod
+		ignoreNotRunning        bool
+		missingRegistryOverride string
+		missingTagPolicy        string
+		dummyTag                string
 	}
 	tests := []struct {
 		name string
@@ -183,9 +188,10 @@ func TestGetContainersFromPods(t *testing.T) {
 						},
 					},
 				},
-				ignoreNotRunning: false,
-				missingTagPolicy: "digest",
-				dummyTag:         "",
+				ignoreNotRunning:        false,
+				missingRegistryOverride: "",
+				missingTagPolicy:        "digest",
+				dummyTag:                "",
 			},
 			want: []Container{
 				{
@@ -249,9 +255,10 @@ func TestGetContainersFromPods(t *testing.T) {
 						},
 					},
 				},
-				ignoreNotRunning: true,
-				missingTagPolicy: "digest",
-				dummyTag:         "",
+				ignoreNotRunning:        true,
+				missingRegistryOverride: "",
+				missingTagPolicy:        "digest",
+				dummyTag:                "",
 			},
 			want: []Container{
 				{
@@ -288,9 +295,10 @@ func TestGetContainersFromPods(t *testing.T) {
 						},
 					},
 				},
-				ignoreNotRunning: false,
-				missingTagPolicy: "digest",
-				dummyTag:         "",
+				ignoreNotRunning:        false,
+				missingRegistryOverride: "",
+				missingTagPolicy:        "digest",
+				dummyTag:                "",
 			},
 			want: []Container{
 				{
@@ -348,9 +356,10 @@ func TestGetContainersFromPods(t *testing.T) {
 						},
 					},
 				},
-				ignoreNotRunning: false,
-				missingTagPolicy: "drop",
-				dummyTag:         "",
+				ignoreNotRunning:        false,
+				missingRegistryOverride: "",
+				missingTagPolicy:        "drop",
+				dummyTag:                "",
 			},
 			want: []Container{
 				{
@@ -387,9 +396,10 @@ func TestGetContainersFromPods(t *testing.T) {
 						},
 					},
 				},
-				ignoreNotRunning: false,
-				missingTagPolicy: "dummy",
-				dummyTag:         "UNKNOWN",
+				ignoreNotRunning:        false,
+				missingRegistryOverride: "",
+				missingTagPolicy:        "dummy",
+				dummyTag:                "UNKNOWN",
 			},
 			want: []Container{
 				{
@@ -400,10 +410,142 @@ func TestGetContainersFromPods(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "successfully returns with an overridden registry",
+			args: args{
+				pods: []v1.Pod{
+					{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Name:  "test-container",
+									Image: "reponame/myimage:0.0.1",
+								},
+							},
+						},
+						Status: v1.PodStatus{
+							ContainerStatuses: []v1.ContainerStatus{
+								{
+									Name:        "test-container",
+									Image:       "reponame/myimage:0.0.1",
+									ImageID:     "docker.io/reponame/myimage@sha256:2e500d29e9d5f4a086b908eb8dfe7ecac57d2ab09d65b24f588b1d449841ef93",
+									ContainerID: "docker://a9cd75ad99dd4363bbd882b40e753b58c62bfd7b03cabeb764c1dac97568ad26",
+								},
+							},
+							Phase: v1.PodRunning,
+						},
+					},
+					{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{
+								{
+									Name:  "test-container2",
+									Image: "docker.io/kubernetesui/dashboard:v2.7.0@sha256:2e500d29e9d5f4a086b908eb8dfe7ecac",
+								},
+							},
+						},
+						Status: v1.PodStatus{
+							ContainerStatuses: []v1.ContainerStatus{
+								{
+									Name:        "test-container2",
+									Image:       "sha256:20b332c9a70d8516d849d1ac23eff5800cbb2f263d379f0ec11ee908db6b25a8",
+									ImageID:     "docker-pullable://kubernetesui/dashboard@sha256:2e500d29e9d5f4a086b908eb8dfe7ecac57d2ab09d65b24f588b1d449841ef93",
+									ContainerID: "docker://a9cd75ad99dd4363bbd882b40e753b58c62bfd7b03cabeb764c1dac97568ad26",
+								},
+							},
+							Phase: v1.PodRunning,
+						},
+					},
+				},
+				ignoreNotRunning:        false,
+				missingRegistryOverride: "custom.registry.io",
+				missingTagPolicy:        "digest",
+				dummyTag:                "",
+			},
+			want: []Container{
+				{
+					Name:        "test-container",
+					ImageTag:    "custom.registry.io/reponame/myimage:0.0.1",
+					ImageDigest: "sha256:2e500d29e9d5f4a086b908eb8dfe7ecac57d2ab09d65b24f588b1d449841ef93",
+					ID:          "docker://a9cd75ad99dd4363bbd882b40e753b58c62bfd7b03cabeb764c1dac97568ad26",
+				},
+				{
+					Name:        "test-container2",
+					ImageTag:    "docker.io/kubernetesui/dashboard:v2.7.0",
+					ImageDigest: "sha256:2e500d29e9d5f4a086b908eb8dfe7ecac57d2ab09d65b24f588b1d449841ef93",
+					ID:          "docker://a9cd75ad99dd4363bbd882b40e753b58c62bfd7b03cabeb764c1dac97568ad26",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetContainersFromPods(tt.args.pods, tt.args.ignoreNotRunning, tt.args.missingTagPolicy, tt.args.dummyTag)
+			got := GetContainersFromPods(
+				tt.args.pods,
+				tt.args.ignoreNotRunning,
+				tt.args.missingRegistryOverride,
+				tt.args.missingTagPolicy,
+				tt.args.dummyTag,
+			)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_getRegistryOverrideNormalisedImageTag(t *testing.T) {
+	type args struct {
+		imageTag                string
+		missingRegistryOverride string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "successfully returns image tag with overridden registry",
+			args: args{
+				imageTag:                "reponame/myimage:0.0.1",
+				missingRegistryOverride: "custom.registry.io",
+			},
+			want: "custom.registry.io/reponame/myimage:0.0.1",
+		},
+		{
+			name: "successfully returns valid image tag without overridden registry",
+			args: args{
+				imageTag:                "docker.io/reponame/myimage:0.0.1",
+				missingRegistryOverride: "custom.registry.io",
+			},
+			want: "docker.io/reponame/myimage:0.0.1",
+		},
+		{
+			name: "successfully returns valid image tag without overridden registry (includes library)",
+			args: args{
+				imageTag:                "docker.io/library/reponame/myimage:0.0.1",
+				missingRegistryOverride: "custom.registry.io",
+			},
+			want: "docker.io/library/reponame/myimage:0.0.1",
+		},
+		{
+			name: "successfully returns valid image tag no repo",
+			args: args{
+				imageTag:                "myimage:0.0.1",
+				missingRegistryOverride: "custom.registry.io",
+			},
+			want: "custom.registry.io/myimage:0.0.1",
+		},
+		{
+			name: "returns image tag without overridden registry if library and repo are present but no registry (cannot determine between library and domain)",
+			args: args{
+				imageTag:                "library/reponame/myimage:0.0.1",
+				missingRegistryOverride: "custom.registry.io",
+			},
+			want: "library/reponame/myimage:0.0.1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getRegistryOverrideNormalisedImageTag(tt.args.imageTag, tt.args.missingRegistryOverride)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/lib.go
+++ b/pkg/lib.go
@@ -245,6 +245,7 @@ func processNamespace(
 	containers := inventory.GetContainersFromPods(
 		v1pods,
 		cfg.IgnoreNotRunning,
+		cfg.MissingRegistryOverride,
 		cfg.MissingTagPolicy.Policy,
 		cfg.MissingTagPolicy.Tag,
 	)


### PR DESCRIPTION
If kubernetes does not provide a registry for an image give the option
to return the pull string to Anchore Enterprise with a default registry
set for the image.

Signed-off-by: Bradley Jones <bradley.jones@anchore.com>
