### PR TITLE
fix: send to default account on 403 from Anchore

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,7 +66,7 @@ var rootCmd = &cobra.Command{
 					if appConfig.AccountRouteByNamespaceLabel.DefaultAccount != "" {
 						retryAccount = appConfig.AccountRouteByNamespaceLabel.DefaultAccount
 					}
-					log.Warnf("Anchore Account %s does not exist, sending to default account", account)
+					log.Warnf("Error sending to Anchore Account %s, sending to default account", account)
 					err = pkg.HandleReport(report, appConfig, retryAccount)
 				}
 				if err != nil {

--- a/pkg/lib.go
+++ b/pkg/lib.go
@@ -107,7 +107,7 @@ func PeriodicallyGetInventoryReport(cfg *config.Application) {
 					if cfg.AccountRouteByNamespaceLabel.DefaultAccount != "" {
 						retryAccount = cfg.AccountRouteByNamespaceLabel.DefaultAccount
 					}
-					log.Warnf("Anchore Account %s does not exist, sending to default account", account)
+					log.Warnf("Error sending to Anchore Account %s, sending to default account", account)
 					err = HandleReport(report, cfg, retryAccount)
 				}
 				if err != nil {

--- a/pkg/reporter/reporter.go
+++ b/pkg/reporter/reporter.go
@@ -80,7 +80,11 @@ func Post(report inventory.Report, anchoreDetails config.AnchoreInfo) error {
 		return fmt.Errorf("failed to report data to Anchore: %w", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode == 404 {
+	switch {
+	case resp.StatusCode == 403:
+		log.Debug("Forbidden response (403) from Anchore")
+		return ErrAnchoreAccountDoesNotExist
+	case resp.StatusCode == 404:
 		previousVersion := enterpriseEndpoint
 		// We failed to send the inventory.  We need to check the version of Enterprise.
 		versionError := checkVersion(anchoreDetails)


### PR DESCRIPTION
Non admin accounts will respond with 403 on 'missing' account due to not
having the correct permissions to see other accounts. In this case we
should also route to the default account.

Signed-off-by: Bradley Jones <bradley.jones@anchore.com>
