### PR TITLE
feat: bump go to 1.22.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/anchore/k8s-inventory
 
-go 1.22.2
+go 1.22.5
 
 require (
 	github.com/adrg/xdg v0.4.0

--- a/scripts/install-go.sh
+++ b/scripts/install-go.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-GO_VERSION="1.22.2"
+GO_VERSION="1.22.5"
 ARCH=$(uname | tr '[:upper:]' '[:lower:]')
 GO_ARTIFACT="go$GO_VERSION.$ARCH-amd64.tar.gz"
 wget "https://dl.google.com/go/$GO_ARTIFACT"


### PR DESCRIPTION
addresses CVE-2024-24790

Signed-off-by: Bradley Jones <bradley.jones@anchore.com>
