### PR TITLE
fix: redact passwords under account-routes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/anchore/go-testutils v0.0.0-20200925183923-d5f45b0d3c04
 	github.com/h2non/gock v1.2.0
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/viper v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
+github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1 h1:dOYG7LS/WK00RWZc8XGgcUTlTxpp3mKhdR2Q9z9HbXM=
+github.com/nsf/jsondiff v0.0.0-20230430225905-43f6cf3098c1/go.mod h1:mpRZBD8SJ55OIICQ3iWH0Yz3cjzA61JdqMLoWXeB2+8=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,13 +10,13 @@ are listed below in order of precedence:
 */package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"path"
 	"strings"
 
-	"gopkg.in/yaml.v2"
-
 	"github.com/anchore/k8s-inventory/pkg/mode"
+	"gopkg.in/yaml.v2"
 
 	"github.com/adrg/xdg"
 	"github.com/mitchellh/go-homedir"
@@ -37,106 +37,106 @@ type CliOnlyOptions struct {
 // All Application configurations
 type Application struct {
 	ConfigPath                      string
-	Quiet                           bool    `mapstructure:"quiet"`
-	Log                             Logging `mapstructure:"log"`
+	Quiet                           bool    `mapstructure:"quiet" json:"quiet,omitempty" yaml:"quiet"`
+	Log                             Logging `mapstructure:"log" json:"log,omitempty" yaml:"log"`
 	CliOptions                      CliOnlyOptions
-	Dev                             Development                  `mapstructure:"dev"`
-	KubeConfig                      KubeConf                     `mapstructure:"kubeconfig"`
-	Kubernetes                      KubernetesAPI                `mapstructure:"kubernetes"`
-	Namespaces                      []string                     `mapstructure:"namespaces"`
-	KubernetesRequestTimeoutSeconds int64                        `mapstructure:"kubernetes-request-timeout-seconds"`
-	NamespaceSelectors              NamespaceSelector            `mapstructure:"namespace-selectors"`
-	AccountRoutes                   AccountRoutes                `mapstructure:"account-routes"`
-	AccountRouteByNamespaceLabel    AccountRouteByNamespaceLabel `mapstructure:"account-route-by-namespace-label"`
-	MissingRegistryOverride         string                       `mapstructure:"missing-registry-override"`
-	MissingTagPolicy                MissingTagConf               `mapstructure:"missing-tag-policy"`
+	Dev                             Development                  `mapstructure:"dev" json:"dev,omitempty" yaml:"dev"`
+	KubeConfig                      KubeConf                     `mapstructure:"kubeconfig" json:"kubeconfig,omitempty" yaml:"kubeconfig"`
+	Kubernetes                      KubernetesAPI                `mapstructure:"kubernetes" json:"kubernetes,omitempty" yaml:"kubernetes"`
+	Namespaces                      []string                     `mapstructure:"namespaces" json:"namespaces,omitempty" yaml:"namespaces"`
+	KubernetesRequestTimeoutSeconds int64                        `mapstructure:"kubernetes-request-timeout-seconds" json:"kubernetes-request-timeout-seconds,omitempty" yaml:"kubernetes-request-timeout-seconds"`
+	NamespaceSelectors              NamespaceSelector            `mapstructure:"namespace-selectors" json:"namespace-selectors,omitempty" yaml:"namespace-selectors"`
+	AccountRoutes                   AccountRoutes                `mapstructure:"account-routes" json:"account-routes,omitempty" yaml:"account-routes"`
+	AccountRouteByNamespaceLabel    AccountRouteByNamespaceLabel `mapstructure:"account-route-by-namespace-label" json:"account-route-by-namespace-label,omitempty" yaml:"account-route-by-namespace-label"`
+	MissingRegistryOverride         string                       `mapstructure:"missing-registry-override" json:"missing-registry-override,omitempty" yaml:"missing-registry-override"`
+	MissingTagPolicy                MissingTagConf               `mapstructure:"missing-tag-policy" json:"missing-tag-policy,omitempty" yaml:"missing-tag-policy"`
 	RunMode                         mode.Mode
-	Mode                            string                `mapstructure:"mode"`
-	IgnoreNotRunning                bool                  `mapstructure:"ignore-not-running"`
-	PollingIntervalSeconds          int                   `mapstructure:"polling-interval-seconds"`
-	InventoryReportLimits           InventoryReportLimits `mapstructure:"inventory-report-limits"`
-	MetadataCollection              MetadataCollection    `mapstructure:"metadata-collection"`
-	AnchoreDetails                  AnchoreInfo           `mapstructure:"anchore"`
-	VerboseInventoryReports         bool                  `mapstructure:"verbose-inventory-reports"`
+	Mode                            string                `mapstructure:"mode" json:"mode,omitempty" yaml:"mode"`
+	IgnoreNotRunning                bool                  `mapstructure:"ignore-not-running" json:"ignore-not-running,omitempty" yaml:"ignore-not-running"`
+	PollingIntervalSeconds          int                   `mapstructure:"polling-interval-seconds" json:"polling-interval-seconds,omitempty" yaml:"polling-interval-seconds"`
+	InventoryReportLimits           InventoryReportLimits `mapstructure:"inventory-report-limits" json:"inventory-report-limits,omitempty" yaml:"inventory-report-limits"`
+	MetadataCollection              MetadataCollection    `mapstructure:"metadata-collection" json:"metadata-collection,omitempty" yaml:"metadata-collection"`
+	AnchoreDetails                  AnchoreInfo           `mapstructure:"anchore" json:"anchore,omitempty" yaml:"anchore"`
+	VerboseInventoryReports         bool                  `mapstructure:"verbose-inventory-reports" json:"verbose-inventory-reports,omitempty" yaml:"verbose-inventory-reports"`
 }
 
 // MissingTagConf details the policy for handling missing tags when reporting images
 type MissingTagConf struct {
-	Policy string `mapstructure:"policy"`
-	Tag    string `mapstructure:"tag,omitempty"`
+	Policy string `mapstructure:"policy" json:"policy,omitempty" yaml:"policy"`
+	Tag    string `mapstructure:"tag,omitempty" json:"tag,omitempty" yaml:"tag"`
 }
 
 // NamespaceSelector details the inclusion/exclusion rules for namespaces
 type NamespaceSelector struct {
-	Include     []string `mapstructure:"include"`
-	Exclude     []string `mapstructure:"exclude"`
-	IgnoreEmpty bool     `mapstructure:"ignore-empty"`
+	Include     []string `mapstructure:"include" json:"include,omitempty" yaml:"include"`
+	Exclude     []string `mapstructure:"exclude" json:"exclude,omitempty" yaml:"exclude"`
+	IgnoreEmpty bool     `mapstructure:"ignore-empty" json:"ignore-empty,omitempty" yaml:"ignore-empty"`
 }
 
 type AccountRoutes map[string]AccountRouteDetails
 
 type AccountRouteDetails struct {
-	User       string   `mapstructure:"user"`
-	Password   string   `mapstructure:"password"`
-	Namespaces []string `mapstructure:"namespaces"`
+	User       string   `mapstructure:"user" json:"user,omitempty" yaml:"user"`
+	Password   string   `mapstructure:"password" json:"password,omitempty" yaml:"password"`
+	Namespaces []string `mapstructure:"namespaces" json:"namespaces,omitempty" yaml:"namespaces"`
 }
 
 type AccountRouteByNamespaceLabel struct {
-	LabelKey           string `mapstructure:"key"`
-	DefaultAccount     string `mapstructure:"default-account"`
-	IgnoreMissingLabel bool   `mapstructure:"ignore-missing-label"`
+	LabelKey           string `mapstructure:"key" json:"key,omitempty" yaml:"key"`
+	DefaultAccount     string `mapstructure:"default-account" json:"default-account,omitempty" yaml:"default-account"`
+	IgnoreMissingLabel bool   `mapstructure:"ignore-missing-label" json:"ignore-missing-label,omitempty" yaml:"ignore-missing-label"`
 }
 
 // KubernetesAPI details the configuration for interacting with the k8s api server
 type KubernetesAPI struct {
-	RequestTimeoutSeconds int64 `mapstructure:"request-timeout-seconds"`
-	RequestBatchSize      int64 `mapstructure:"request-batch-size"`
-	WorkerPoolSize        int   `mapstructure:"worker-pool-size"`
+	RequestTimeoutSeconds int64 `mapstructure:"request-timeout-seconds" json:"request-timeout-second,omitempty" yaml:"request-timeout-seconds"`
+	RequestBatchSize      int64 `mapstructure:"request-batch-size" json:"request-batch-size,omitempty" yaml:"request-batch-size"`
+	WorkerPoolSize        int   `mapstructure:"worker-pool-size" json:"worker-pool-size,omitempty" yaml:"worker-pool-size"`
 }
 
 // Details upper limits for the inventory report contents before splitting into batches
 type InventoryReportLimits struct {
-	Namespaces int `mapstructure:"namespaces"`
+	Namespaces int `mapstructure:"namespaces" json:"namespaces,omitempty" yaml:"namespaces"`
 }
 
 type ResourceMetadata struct {
-	Annotations []string `json:"include-annotations"`
-	Labels      []string `json:"include-labels"`
-	Disable     bool     `json:"disable-all-metadata"`
+	Annotations []string `mapstructure:"include-annotations" json:"include-annotations,omitempty" yaml:"include-annotations"`
+	Labels      []string `mapstructure:"include-labels" json:"include-labels,omitempty" yaml:"include-labels"`
+	Disable     bool     `mapstructure:"disable" json:"disable,omitempty" yaml:"disable"`
 }
 
 type MetadataCollection struct {
-	Nodes     ResourceMetadata `mapstructure:"nodes"`
-	Namespace ResourceMetadata `mapstructure:"namespaces"`
-	Pods      ResourceMetadata `mapstructure:"pods"`
+	Nodes     ResourceMetadata `mapstructure:"nodes" json:"nodes,omitempty" yaml:"nodes"`
+	Namespace ResourceMetadata `mapstructure:"namespaces" json:"namespace,omitempty" yaml:"namespaces"`
+	Pods      ResourceMetadata `mapstructure:"pods" json:"pods,omitempty" yaml:"pods"`
 }
 
 // Information for posting in-use image details to Anchore (or any URL for that matter)
 type AnchoreInfo struct {
-	URL      string     `mapstructure:"url"`
-	User     string     `mapstructure:"user"`
-	Password string     `mapstructure:"password"`
-	Account  string     `mapstructure:"account"`
-	HTTP     HTTPConfig `mapstructure:"http"`
+	URL      string     `mapstructure:"url" json:"url,omitempty" yaml:"url"`
+	User     string     `mapstructure:"user" json:"user,omitempty" yaml:"user"`
+	Password string     `mapstructure:"password" json:"password,omitempty" yaml:"password"`
+	Account  string     `mapstructure:"account" json:"account,omitempty" yaml:"account"`
+	HTTP     HTTPConfig `mapstructure:"http" json:"http,omitempty" yaml:"http"`
 }
 
 // Configurations for the HTTP Client itself (net/http)
 type HTTPConfig struct {
-	Insecure       bool `mapstructure:"insecure"`
-	TimeoutSeconds int  `mapstructure:"timeout-seconds"`
+	Insecure       bool `mapstructure:"insecure" json:"insecure,omitempty" yaml:"insecure"`
+	TimeoutSeconds int  `mapstructure:"timeout-seconds" json:"timeout-seconds,omitempty" yaml:"timeout-seconds"`
 }
 
 // Logging Configuration
 type Logging struct {
-	Structured   bool `mapstructure:"structured"`
+	Structured   bool `mapstructure:"structured" json:"structured,omitempty" yaml:"structured"`
 	LevelOpt     logrus.Level
-	Level        string `mapstructure:"level"`
-	FileLocation string `mapstructure:"file"`
+	Level        string `mapstructure:"level" json:"level,omitempty" yaml:"level"`
+	FileLocation string `mapstructure:"file" json:"file,omitempty" yaml:"file"`
 }
 
 // Development Configuration (only profile-cpu at the moment)
 type Development struct {
-	ProfileCPU bool `mapstructure:"profile-cpu"`
+	ProfileCPU bool `mapstructure:"profile-cpu" json:"profile-cpu,omitempty" yaml:"profile-cpu"`
 }
 
 // Return whether or not AnchoreDetails are specified
@@ -334,21 +334,6 @@ func readConfig(v *viper.Viper, configPath string) error {
 }
 
 func (cfg Application) String() string {
-	// redact sensitive information
-	// Note: If the configuration grows to have more redacted fields it would be good to refactor this into something that
-	// is more dynamic based on a property or list of "sensitive" fields
-	if cfg.AnchoreDetails.Password != "" {
-		cfg.AnchoreDetails.Password = redacted
-	}
-
-	if cfg.KubeConfig.User.PrivateKey != "" {
-		cfg.KubeConfig.User.PrivateKey = redacted
-	}
-
-	if cfg.KubeConfig.User.Token != "" {
-		cfg.KubeConfig.User.Token = redacted
-	}
-
 	// yaml is pretty human friendly (at least when compared to json)
 	appCfgStr, err := yaml.Marshal(&cfg)
 	if err != nil {
@@ -356,4 +341,38 @@ func (cfg Application) String() string {
 	}
 
 	return string(appCfgStr)
+}
+
+func (anchore AnchoreInfo) MarshalJSON() ([]byte, error) {
+	type anchoreInfoAlias AnchoreInfo // prevent recursion
+
+	aIA := anchoreInfoAlias(anchore)
+	if aIA.Password != "" {
+		aIA.Password = redacted
+	}
+	return json.Marshal(aIA)
+}
+
+func (anchore AnchoreInfo) MarshalYAML() (interface{}, error) {
+	if anchore.Password != "" {
+		anchore.Password = redacted
+	}
+	return anchore, nil
+}
+
+func (aRD AccountRouteDetails) MarshalJSON() ([]byte, error) {
+	type AccountRouteDetailsAlias AccountRouteDetails // prevent recursion
+
+	aRDA := AccountRouteDetailsAlias(aRD)
+	if aRDA.Password != "" {
+		aRDA.Password = redacted
+	}
+	return json.Marshal(aRDA)
+}
+
+func (aRD AccountRouteDetails) MarshalYAML() (interface{}, error) {
+	if aRD.Password != "" {
+		aRD.Password = redacted
+	}
+	return aRD, nil
 }

--- a/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
@@ -4,67 +4,67 @@ log:
   structured: false
   levelopt: debug
   level: debug
-  filelocation: ./anchore-k8s-inventory.log
+  file: ./anchore-k8s-inventory.log
 clioptions:
   configpath: ../../anchore-k8s-inventory.yaml
   verbosity: 0
 dev:
-  profilecpu: false
+  profile-cpu: false
 kubeconfig:
   path: ""
   cluster: docker-desktop
-  clustercert: ""
+  cluster-cert: ""
   server: ""
   user:
     userconftype: 0
-    userconf: ""
-    clientcert: ""
-    privatekey: ""
+    type: ""
+    client-cert: ""
+    private-key: ""
     token: ""
 kubernetes:
-  requesttimeoutseconds: 60
-  requestbatchsize: 100
-  workerpoolsize: 100
+  request-timeout-seconds: 60
+  request-batch-size: 100
+  worker-pool-size: 100
 namespaces: []
-kubernetesrequesttimeoutseconds: -1
-namespaceselectors:
+kubernetes-request-timeout-seconds: -1
+namespace-selectors:
   include: []
   exclude: []
-  ignoreempty: false
-accountroutes: {}
-accountroutebynamespacelabel:
-  labelkey: ""
-  defaultaccount: ""
-  ignoremissinglabel: false
-missingregistryoverride: ""
-missingtagpolicy:
+  ignore-empty: false
+account-routes: {}
+account-route-by-namespace-label:
+  key: ""
+  default-account: ""
+  ignore-missing-label: false
+missing-registry-override: ""
+missing-tag-policy:
   policy: digest
   tag: UNKNOWN
 runmode: 0
 mode: adhoc
-ignorenotrunning: true
-pollingintervalseconds: 300
-inventoryreportlimits:
+ignore-not-running: true
+polling-interval-seconds: 300
+inventory-report-limits:
   namespaces: 0
-metadatacollection:
+metadata-collection:
   nodes:
-    annotations: []
-    labels: []
+    include-annotations: []
+    include-labels: []
     disable: false
-  namespace:
-    annotations: []
-    labels: []
+  namespaces:
+    include-annotations: []
+    include-labels: []
     disable: false
   pods:
-    annotations: []
-    labels: []
+    include-annotations: []
+    include-labels: []
     disable: false
-anchoredetails:
+anchore:
   url: ""
   user: ""
   password: '******'
   account: admin
   http:
     insecure: false
-    timeoutseconds: 10
-verboseinventoryreports: false
+    timeout-seconds: 10
+verbose-inventory-reports: false

--- a/internal/config/test-fixtures/snapshot/TestEmptyConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestEmptyConfigString.golden
@@ -4,67 +4,67 @@ log:
   structured: false
   levelopt: panic
   level: ""
-  filelocation: ""
+  file: ""
 clioptions:
   configpath: ""
   verbosity: 0
 dev:
-  profilecpu: false
+  profile-cpu: false
 kubeconfig:
   path: ""
   cluster: ""
-  clustercert: ""
+  cluster-cert: ""
   server: ""
   user:
     userconftype: 0
-    userconf: ""
-    clientcert: ""
-    privatekey: ""
+    type: ""
+    client-cert: ""
+    private-key: ""
     token: ""
 kubernetes:
-  requesttimeoutseconds: 0
-  requestbatchsize: 0
-  workerpoolsize: 0
+  request-timeout-seconds: 0
+  request-batch-size: 0
+  worker-pool-size: 0
 namespaces: []
-kubernetesrequesttimeoutseconds: 0
-namespaceselectors:
+kubernetes-request-timeout-seconds: 0
+namespace-selectors:
   include: []
   exclude: []
-  ignoreempty: false
-accountroutes: {}
-accountroutebynamespacelabel:
-  labelkey: ""
-  defaultaccount: ""
-  ignoremissinglabel: false
-missingregistryoverride: ""
-missingtagpolicy:
+  ignore-empty: false
+account-routes: {}
+account-route-by-namespace-label:
+  key: ""
+  default-account: ""
+  ignore-missing-label: false
+missing-registry-override: ""
+missing-tag-policy:
   policy: ""
   tag: ""
 runmode: 0
 mode: ""
-ignorenotrunning: false
-pollingintervalseconds: 0
-inventoryreportlimits:
+ignore-not-running: false
+polling-interval-seconds: 0
+inventory-report-limits:
   namespaces: 0
-metadatacollection:
+metadata-collection:
   nodes:
-    annotations: []
-    labels: []
+    include-annotations: []
+    include-labels: []
     disable: false
-  namespace:
-    annotations: []
-    labels: []
+  namespaces:
+    include-annotations: []
+    include-labels: []
     disable: false
   pods:
-    annotations: []
-    labels: []
+    include-annotations: []
+    include-labels: []
     disable: false
-anchoredetails:
+anchore:
   url: ""
   user: ""
   password: ""
   account: ""
   http:
     insecure: false
-    timeoutseconds: 0
-verboseinventoryreports: false
+    timeout-seconds: 0
+verbose-inventory-reports: false

--- a/internal/config/test-fixtures/snapshot/TestSensitiveConfigJSON.golden
+++ b/internal/config/test-fixtures/snapshot/TestSensitiveConfigJSON.golden
@@ -1,0 +1,66 @@
+{
+    "ConfigPath": "../../anchore-k8s-inventory.yaml",
+    "log": {
+        "LevelOpt": "debug",
+        "level": "debug",
+        "file": "./anchore-k8s-inventory.log"
+    },
+    "CliOptions": {
+        "ConfigPath": "../../anchore-k8s-inventory.yaml",
+        "Verbosity": 0
+    },
+    "dev": {},
+    "kubeconfig": {
+        "cluster": "docker-desktop",
+        "user": {
+            "UserConfType": 0,
+            "private-key": "******",
+            "token": "******"
+        }
+    },
+    "kubernetes": {
+        "request-timeout-second": 60,
+        "request-batch-size": 100,
+        "worker-pool-size": 100
+    },
+    "kubernetes-request-timeout-seconds": -1,
+    "namespace-selectors": {},
+    "account-routes": {
+        "account0": {
+            "user": "account0User",
+            "password": "******",
+            "namespaces": [
+                "ns-account0"
+            ]
+        },
+        "account2": {
+            "user": "account2User",
+            "password": "******",
+            "namespaces": [
+                "ns-account2"
+            ]
+        }
+    },
+    "account-route-by-namespace-label": {},
+    "missing-tag-policy": {
+        "policy": "digest",
+        "tag": "UNKNOWN"
+    },
+    "RunMode": 0,
+    "mode": "adhoc",
+    "ignore-not-running": true,
+    "polling-interval-seconds": 300,
+    "inventory-report-limits": {},
+    "metadata-collection": {
+        "nodes": {},
+        "namespace": {},
+        "pods": {}
+    },
+    "anchore": {
+        "password": "******",
+        "account": "admin",
+        "http": {
+            "timeout-seconds": 10
+        }
+    }
+}

--- a/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
@@ -4,67 +4,77 @@ log:
   structured: false
   levelopt: debug
   level: debug
-  filelocation: ./anchore-k8s-inventory.log
+  file: ./anchore-k8s-inventory.log
 clioptions:
   configpath: ../../anchore-k8s-inventory.yaml
   verbosity: 0
 dev:
-  profilecpu: false
+  profile-cpu: false
 kubeconfig:
   path: ""
   cluster: docker-desktop
-  clustercert: ""
+  cluster-cert: ""
   server: ""
   user:
     userconftype: 0
-    userconf: ""
-    clientcert: ""
-    privatekey: '******'
+    type: ""
+    client-cert: ""
+    private-key: '******'
     token: '******'
 kubernetes:
-  requesttimeoutseconds: 60
-  requestbatchsize: 100
-  workerpoolsize: 100
+  request-timeout-seconds: 60
+  request-batch-size: 100
+  worker-pool-size: 100
 namespaces: []
-kubernetesrequesttimeoutseconds: -1
-namespaceselectors:
+kubernetes-request-timeout-seconds: -1
+namespace-selectors:
   include: []
   exclude: []
-  ignoreempty: false
-accountroutes: {}
-accountroutebynamespacelabel:
-  labelkey: ""
-  defaultaccount: ""
-  ignoremissinglabel: false
-missingregistryoverride: ""
-missingtagpolicy:
+  ignore-empty: false
+account-routes:
+  account0:
+    user: account0User
+    password: '******'
+    namespaces:
+    - ns-account0
+  account2:
+    user: account2User
+    password: '******'
+    namespaces:
+    - ns-account2
+account-route-by-namespace-label:
+  key: ""
+  default-account: ""
+  ignore-missing-label: false
+missing-registry-override: ""
+missing-tag-policy:
   policy: digest
   tag: UNKNOWN
 runmode: 0
 mode: adhoc
-ignorenotrunning: true
-pollingintervalseconds: 300
-inventoryreportlimits:
+ignore-not-running: true
+polling-interval-seconds: 300
+inventory-report-limits:
   namespaces: 0
-metadatacollection:
+metadata-collection:
   nodes:
-    annotations: []
-    labels: []
+    include-annotations: []
+    include-labels: []
     disable: false
-  namespace:
-    annotations: []
-    labels: []
+  namespaces:
+    include-annotations: []
+    include-labels: []
     disable: false
   pods:
-    annotations: []
-    labels: []
+    include-annotations: []
+    include-labels: []
     disable: false
-anchoredetails:
+anchore:
   url: ""
   user: ""
   password: '******'
   account: admin
   http:
     insecure: false
-    timeoutseconds: 10
-verboseinventoryreports: false
+    timeout-seconds: 10
+verbose-inventory-reports: false


### PR DESCRIPTION
This commit makes changes so that all passwords and private keys are redacted in logs, when json marshalled and when yaml marshalled.

Addresses: ENTERPRISE-4159