### PR TITLE
feat: batch inventory reports by payload size

### DIFF
--- a/anchore-k8s-inventory.yaml
+++ b/anchore-k8s-inventory.yaml
@@ -134,6 +134,7 @@ health-report-interval-seconds: 60
 # Batch Request configuration
 inventory-report-limits:
   namespaces: 0 # default of 0 means no limit per report
+  payload-threshold-bytes: 0 # default of 0 means no limit per report
 
 # Metadata configuration
 metadata-collection:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -104,7 +104,8 @@ type KubernetesAPI struct {
 
 // Details upper limits for the inventory report contents before splitting into batches
 type InventoryReportLimits struct {
-	Namespaces int `mapstructure:"namespaces" json:"namespaces,omitempty" yaml:"namespaces"`
+	Namespaces            int `mapstructure:"namespaces" json:"namespaces,omitempty" yaml:"namespaces"`
+	PayloadThresholdBytes int `mapstructure:"payload-threshold-bytes" json:"payload-threshold-bytes,omitempty" yaml:"payload-threshold-bytes"`
 }
 
 type ResourceMetadata struct {

--- a/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
@@ -51,6 +51,7 @@ polling-interval-seconds: 300
 health-report-interval-seconds: 60
 inventory-report-limits:
   namespaces: 0
+  payload-threshold-bytes: 0
 metadata-collection:
   nodes:
     include-annotations: []

--- a/internal/config/test-fixtures/snapshot/TestEmptyConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestEmptyConfigString.golden
@@ -51,6 +51,7 @@ polling-interval-seconds: 0
 health-report-interval-seconds: 0
 inventory-report-limits:
   namespaces: 0
+  payload-threshold-bytes: 0
 metadata-collection:
   nodes:
     include-annotations: []

--- a/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
@@ -61,6 +61,7 @@ polling-interval-seconds: 300
 health-report-interval-seconds: 60
 inventory-report-limits:
   namespaces: 0
+  payload-threshold-bytes: 0
 metadata-collection:
   nodes:
     include-annotations: []


### PR DESCRIPTION
[ENTERPRISE-6042](https://anchore.atlassian.net/browse/ENTERPRISE-6042)

Adds an additional option to `inventory-report-limits` with a new setting for `payload-bytes`.

When `payload-bytes` is specified, we will perform batching on a namespace boundary as before, but include a dynamic number of namespaces in each batched report based on a rough measure of the overall size of the payload, rather than a fixed count of namespaces.

If both are set, then a new batch will be started when either limit is reached.

[ENTERPRISE-6042]: https://anchore.atlassian.net/browse/ENTERPRISE-6042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ