### PR TITLE
test: improve automated test coverage

### DIFF
--- a/internal/anchore/anchoreclient_test.go
+++ b/internal/anchore/anchoreclient_test.go
@@ -251,6 +251,60 @@ var (
 	}
 )
 
+func TestAPIClientError_Error(t *testing.T) {
+	tests := []struct {
+		name string
+		err  APIClientError
+		want string
+	}{
+		{
+			name: "basic error message",
+			err: APIClientError{
+				HTTPStatusCode: 404,
+				Message:        "Not Found",
+				Path:           "/v2/test",
+				Method:         "GET",
+			},
+			want: `API errorMsg(404): Not Found Path: "/v2/test" <nil> <nil>`,
+		},
+		{
+			name: "error with API details",
+			err: APIClientError{
+				HTTPStatusCode: 403,
+				Message:        "Forbidden",
+				Path:           "/v2/test",
+				Method:         "POST",
+				APIErrorDetails: &APIErrorDetails{
+					Message:  "Not authorized",
+					HTTPCode: 403,
+				},
+			},
+			want: `API errorMsg(403): Forbidden Path: "/v2/test" &{Not authorized map[] 403} <nil>`,
+		},
+		{
+			name: "error with controller details",
+			err: APIClientError{
+				HTTPStatusCode: 404,
+				Message:        "Not Found",
+				Path:           "/v2/test",
+				Method:         "POST",
+				ControllerErrorDetails: &ControllerErrorDetails{
+					Type:   "about:blank",
+					Title:  "Not Found",
+					Detail: "URL not found",
+					Status: 404,
+				},
+			},
+			want: `API errorMsg(404): Not Found Path: "/v2/test" <nil> &{about:blank Not Found URL not found 404}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.err.Error())
+		})
+	}
+}
+
 func TestGetVersion(t *testing.T) {
 	defer gock.Off()
 

--- a/internal/config/kube_config_test.go
+++ b/internal/config/kube_config_test.go
@@ -1,0 +1,318 @@
+package config
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestKubeConf_IsKubeConfigFromFile(t *testing.T) {
+	tests := []struct {
+		name string
+		conf KubeConf
+		want bool
+	}{
+		{
+			name: "path set",
+			conf: KubeConf{Path: "/home/user/.kube/config"},
+			want: true,
+		},
+		{
+			name: "path empty",
+			conf: KubeConf{},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.conf.IsKubeConfigFromFile())
+		})
+	}
+}
+
+func TestKubeConf_IsNonFileKubeConfigValid(t *testing.T) {
+	validPrivateKeyUser := KubeConfUser{
+		UserConfType: PrivateKey,
+		ClientCert:   "cert-data",
+		PrivateKey:   "key-data",
+	}
+	validTokenUser := KubeConfUser{
+		UserConfType: ServiceAccountToken,
+		Token:        "my-token",
+	}
+
+	tests := []struct {
+		name string
+		conf KubeConf
+		want bool
+	}{
+		{
+			name: "all fields set with private key user",
+			conf: KubeConf{
+				Cluster:     "my-cluster",
+				ClusterCert: "cert",
+				Server:      "https://k8s.example.com",
+				User:        validPrivateKeyUser,
+			},
+			want: true,
+		},
+		{
+			name: "all fields set with token user",
+			conf: KubeConf{
+				Cluster:     "my-cluster",
+				ClusterCert: "cert",
+				Server:      "https://k8s.example.com",
+				User:        validTokenUser,
+			},
+			want: true,
+		},
+		{
+			name: "missing cluster",
+			conf: KubeConf{
+				ClusterCert: "cert",
+				Server:      "https://k8s.example.com",
+				User:        validPrivateKeyUser,
+			},
+			want: false,
+		},
+		{
+			name: "missing cluster cert",
+			conf: KubeConf{
+				Cluster: "my-cluster",
+				Server:  "https://k8s.example.com",
+				User:    validPrivateKeyUser,
+			},
+			want: false,
+		},
+		{
+			name: "missing server",
+			conf: KubeConf{
+				Cluster:     "my-cluster",
+				ClusterCert: "cert",
+				User:        validPrivateKeyUser,
+			},
+			want: false,
+		},
+		{
+			name: "invalid user (private key missing cert)",
+			conf: KubeConf{
+				Cluster:     "my-cluster",
+				ClusterCert: "cert",
+				Server:      "https://k8s.example.com",
+				User: KubeConfUser{
+					UserConfType: PrivateKey,
+					PrivateKey:   "key-data",
+				},
+			},
+			want: false,
+		},
+		{
+			name: "invalid user (token missing)",
+			conf: KubeConf{
+				Cluster:     "my-cluster",
+				ClusterCert: "cert",
+				Server:      "https://k8s.example.com",
+				User: KubeConfUser{
+					UserConfType: ServiceAccountToken,
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.conf.IsNonFileKubeConfigValid())
+		})
+	}
+}
+
+func TestKubeConfUser_isValid(t *testing.T) {
+	tests := []struct {
+		name string
+		user KubeConfUser
+		want bool
+	}{
+		{
+			name: "private key with cert and key",
+			user: KubeConfUser{
+				UserConfType: PrivateKey,
+				ClientCert:   "cert",
+				PrivateKey:   "key",
+			},
+			want: true,
+		},
+		{
+			name: "private key missing client cert",
+			user: KubeConfUser{
+				UserConfType: PrivateKey,
+				PrivateKey:   "key",
+			},
+			want: false,
+		},
+		{
+			name: "private key missing private key",
+			user: KubeConfUser{
+				UserConfType: PrivateKey,
+				ClientCert:   "cert",
+			},
+			want: false,
+		},
+		{
+			name: "service account token with token",
+			user: KubeConfUser{
+				UserConfType: ServiceAccountToken,
+				Token:        "my-token",
+			},
+			want: true,
+		},
+		{
+			name: "service account token without token",
+			user: KubeConfUser{
+				UserConfType: ServiceAccountToken,
+			},
+			want: false,
+		},
+		{
+			name: "default user type is always valid",
+			user: KubeConfUser{
+				UserConfType: UserConf(99),
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.user.isValid())
+		})
+	}
+}
+
+func TestKubeConf_GetKubeConfigFromConf_ServiceAccountToken(t *testing.T) {
+	cert := "test-ca-cert-data"
+	encodedCert := base64.StdEncoding.EncodeToString([]byte(cert))
+
+	kubeConf := &KubeConf{
+		Cluster:     "test-cluster",
+		ClusterCert: encodedCert,
+		Server:      "https://k8s.example.com:6443",
+		User: KubeConfUser{
+			UserConfType: ServiceAccountToken,
+			Token:        "my-sa-token",
+		},
+	}
+
+	restConfig, err := kubeConf.GetKubeConfigFromConf()
+	require.NoError(t, err)
+	assert.Equal(t, "https://k8s.example.com:6443", restConfig.Host)
+	assert.Equal(t, "my-sa-token", restConfig.BearerToken)
+}
+
+func TestKubeConf_GetKubeConfigFromConf_PrivateKey(t *testing.T) {
+	cert := "test-ca-cert-data"
+	clientCert := "test-client-cert"
+	privateKey := "test-private-key"
+
+	kubeConf := &KubeConf{
+		Cluster:     "test-cluster",
+		ClusterCert: base64.StdEncoding.EncodeToString([]byte(cert)),
+		Server:      "https://k8s.example.com:6443",
+		User: KubeConfUser{
+			UserConfType: PrivateKey,
+			ClientCert:   base64.StdEncoding.EncodeToString([]byte(clientCert)),
+			PrivateKey:   base64.StdEncoding.EncodeToString([]byte(privateKey)),
+		},
+	}
+
+	restConfig, err := kubeConf.GetKubeConfigFromConf()
+	require.NoError(t, err)
+	assert.Equal(t, "https://k8s.example.com:6443", restConfig.Host)
+	assert.Equal(t, []byte(clientCert), restConfig.CertData)
+	assert.Equal(t, []byte(privateKey), restConfig.KeyData)
+}
+
+func TestKubeConf_GetKubeConfigFromConf_InvalidBase64Cert(t *testing.T) {
+	kubeConf := &KubeConf{
+		Cluster:     "test-cluster",
+		ClusterCert: "not-valid-base64!!!",
+		Server:      "https://k8s.example.com:6443",
+		User: KubeConfUser{
+			UserConfType: ServiceAccountToken,
+			Token:        "token",
+		},
+	}
+
+	_, err := kubeConf.GetKubeConfigFromConf()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to base64 decode cluster cert")
+}
+
+func TestKubeConf_getAuthInfosFromConf_InvalidBase64ClientCert(t *testing.T) {
+	kubeConf := &KubeConf{
+		Cluster: "test-cluster",
+		User: KubeConfUser{
+			UserConfType: PrivateKey,
+			ClientCert:   "not-valid-base64!!!",
+			PrivateKey:   base64.StdEncoding.EncodeToString([]byte("key")),
+		},
+	}
+
+	_, err := kubeConf.getAuthInfosFromConf()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to base64 decode client cert")
+}
+
+func TestKubeConf_getAuthInfosFromConf_InvalidBase64PrivateKey(t *testing.T) {
+	kubeConf := &KubeConf{
+		Cluster: "test-cluster",
+		User: KubeConfUser{
+			UserConfType: PrivateKey,
+			ClientCert:   base64.StdEncoding.EncodeToString([]byte("cert")),
+			PrivateKey:   "not-valid-base64!!!",
+		},
+	}
+
+	_, err := kubeConf.getAuthInfosFromConf()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to base64 decode private key")
+}
+
+func TestKubeConfUser_MarshalJSON_RedactsSensitiveFields(t *testing.T) {
+	user := KubeConfUser{
+		UserConfType: PrivateKey,
+		ClientCert:   "visible-cert",
+		PrivateKey:   "secret-key",
+		Token:        "secret-token",
+	}
+
+	data, err := json.Marshal(user)
+	require.NoError(t, err)
+
+	var unmarshaled map[string]interface{}
+	err = json.Unmarshal(data, &unmarshaled)
+	require.NoError(t, err)
+
+	assert.Equal(t, "visible-cert", unmarshaled["client-cert"])
+	assert.Equal(t, redacted, unmarshaled["private-key"])
+	assert.Equal(t, redacted, unmarshaled["token"])
+}
+
+func TestKubeConfUser_MarshalYAML_RedactsSensitiveFields(t *testing.T) {
+	user := KubeConfUser{
+		UserConfType: PrivateKey,
+		ClientCert:   "visible-cert",
+		PrivateKey:   "secret-key",
+		Token:        "secret-token",
+	}
+
+	result, err := user.MarshalYAML()
+	require.NoError(t, err)
+
+	redactedUser, ok := result.(KubeConfUser)
+	require.True(t, ok)
+	assert.Equal(t, "visible-cert", redactedUser.ClientCert)
+	assert.Equal(t, redacted, redactedUser.PrivateKey)
+	assert.Equal(t, redacted, redactedUser.Token)
+}

--- a/internal/config/user_config_test.go
+++ b/internal/config/user_config_test.go
@@ -1,0 +1,87 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseUserConf(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  UserConf
+	}{
+		{
+			name:  "token string",
+			input: "token",
+			want:  ServiceAccountToken,
+		},
+		{
+			name:  "token uppercase",
+			input: "TOKEN",
+			want:  ServiceAccountToken,
+		},
+		{
+			name:  "token mixed case",
+			input: "Token",
+			want:  ServiceAccountToken,
+		},
+		{
+			name:  "private_key string",
+			input: "private_key",
+			want:  PrivateKey,
+		},
+		{
+			name:  "unknown defaults to PrivateKey",
+			input: "unknown",
+			want:  PrivateKey,
+		},
+		{
+			name:  "empty defaults to PrivateKey",
+			input: "",
+			want:  PrivateKey,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseUserConf(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestUserConf_String(t *testing.T) {
+	tests := []struct {
+		name string
+		conf UserConf
+		want string
+	}{
+		{
+			name: "PrivateKey",
+			conf: PrivateKey,
+			want: "private_key",
+		},
+		{
+			name: "ServiceAccountToken",
+			conf: ServiceAccountToken,
+			want: "token",
+		},
+		{
+			name: "negative value defaults to private_key",
+			conf: UserConf(-1),
+			want: "private_key",
+		},
+		{
+			name: "out of range value defaults to private_key",
+			conf: UserConf(99),
+			want: "private_key",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.conf.String()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/lib_test.go
+++ b/pkg/lib_test.go
@@ -1,12 +1,18 @@
 package pkg
 
 import (
+	"bytes"
+	"encoding/json"
+	"os"
 	"sort"
 	"testing"
 
 	"github.com/anchore/k8s-inventory/internal/config"
+	"github.com/anchore/k8s-inventory/pkg/healthreporter"
 	"github.com/anchore/k8s-inventory/pkg/inventory"
+	"github.com/h2non/gock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -733,6 +739,174 @@ func Test_getBatchedInventoryReportsByNamespace(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestReportToStdout(t *testing.T) {
+	report := inventory.Report{
+		ClusterName: "test-cluster",
+		Timestamp:   "2024-01-01T00:00:00Z",
+		Containers:  []inventory.Container{},
+		Pods:        []inventory.Pod{},
+		Namespaces:  []inventory.Namespace{},
+		Nodes:       []inventory.Node{},
+	}
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	os.Stdout = w
+	err = reportToStdout(report)
+	w.Close()
+	os.Stdout = oldStdout
+
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+
+	// Verify JSON output
+	var decoded inventory.Report
+	err = json.Unmarshal(buf.Bytes(), &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, "test-cluster", decoded.ClusterName)
+	assert.Equal(t, "2024-01-01T00:00:00Z", decoded.Timestamp)
+}
+
+func TestHandleReport(t *testing.T) {
+	tests := []struct {
+		name      string
+		report    inventory.Report
+		cfg       *config.Application
+		account   string
+		wantErr   bool
+		errString string
+	}{
+		{
+			name:   "empty account returns error",
+			report: inventory.Report{},
+			cfg: &config.Application{
+				AnchoreDetails: config.AnchoreInfo{
+					URL:      "https://ancho.re",
+					User:     "admin",
+					Password: "foobar",
+					Account:  "admin",
+				},
+			},
+			account:   "",
+			wantErr:   true,
+			errString: "account name is required",
+		},
+		{
+			name:   "invalid anchore details skips posting",
+			report: inventory.Report{},
+			cfg: &config.Application{
+				AnchoreDetails: config.AnchoreInfo{
+					URL:  "https://ancho.re",
+					User: "", // invalid - empty user
+				},
+			},
+			account: "test-account",
+			wantErr: false,
+		},
+		{
+			name:   "valid anchore details posts successfully",
+			report: inventory.Report{ClusterName: "test"},
+			cfg: &config.Application{
+				AnchoreDetails: config.AnchoreInfo{
+					URL:      "https://ancho.re",
+					User:     "admin",
+					Password: "foobar",
+					Account:  "admin",
+					HTTP: config.HTTPConfig{
+						TimeoutSeconds: 10,
+						Insecure:       true,
+					},
+				},
+			},
+			account: "test-account",
+			wantErr: false,
+		},
+		{
+			name:   "account route overrides credentials",
+			report: inventory.Report{ClusterName: "test"},
+			cfg: &config.Application{
+				AnchoreDetails: config.AnchoreInfo{
+					URL:      "https://ancho.re",
+					User:     "default-user",
+					Password: "default-pass",
+					Account:  "admin",
+					HTTP: config.HTTPConfig{
+						TimeoutSeconds: 10,
+						Insecure:       true,
+					},
+				},
+				AccountRoutes: config.AccountRoutes{
+					"routed-account": config.AccountRouteDetails{
+						User:     "route-user",
+						Password: "route-pass",
+					},
+				},
+			},
+			account: "routed-account",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer gock.Off()
+			// Set up gock mock for tests that will actually post
+			if tt.cfg.AnchoreDetails.IsValid() && tt.account != "" {
+				gock.New("https://ancho.re").
+					Post("/v2/kubernetes-inventory").
+					Reply(201).
+					JSON(map[string]interface{}{})
+			}
+
+			reportInfo := &healthreporter.InventoryReportInfo{}
+			err := HandleReport(tt.report, reportInfo, tt.cfg, tt.account)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.errString != "" {
+					assert.Contains(t, err.Error(), tt.errString)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestHandleReport_VerboseOutput(t *testing.T) {
+	// Test that VerboseInventoryReports triggers stdout output
+	report := inventory.Report{ClusterName: "verbose-test"}
+	cfg := &config.Application{
+		VerboseInventoryReports: true,
+		AnchoreDetails: config.AnchoreInfo{
+			URL:  "",
+			User: "", // invalid - won't try to post
+		},
+	}
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	os.Stdout = w
+	reportInfo := &healthreporter.InventoryReportInfo{}
+	err = HandleReport(report, reportInfo, cfg, "test-account")
+	w.Close()
+	os.Stdout = oldStdout
+
+	assert.NoError(t, err)
+
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	assert.Contains(t, buf.String(), "verbose-test")
 }
 
 func Test_getBatchedInventoryReportsByPayload(t *testing.T) {


### PR DESCRIPTION
Overall coverage: 67.8% -> 73.4% (+5.6 percentage points)                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                            
  New test files created                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                            
  1. internal/config/user_config_test.go - 10 test cases                                                                                                                                                                                                                    
    - TestParseUserConf - token, private_key, unknown, empty string inputs                                                                                                                                                                                                  
    - TestUserConf_String - valid enums and out-of-range values                                                                                                                                                                                                             
  2. internal/config/kube_config_test.go - 24 test cases                                                                                                                                                                                                                    
    - TestKubeConf_IsKubeConfigFromFile - path set/empty
    - TestKubeConf_IsNonFileKubeConfigValid - 7 field combination scenarios
    - TestKubeConfUser_isValid - PrivateKey, ServiceAccountToken, default
    - TestKubeConf_GetKubeConfigFromConf_* - ServiceAccountToken, PrivateKey, invalid base64
    - TestKubeConf_getAuthInfosFromConf_* - invalid base64 client cert and private key
    - TestKubeConfUser_MarshalJSON/YAML_RedactsSensitiveFields - redaction verification

  Existing test files extended

  3. pkg/lib_test.go - 9 new test cases
    - TestReportToStdout - stdout JSON encoding verification
    - TestHandleReport - 4 scenarios: empty account, invalid config, successful post, account route override
    - TestHandleReport_VerboseOutput - verbose flag triggers stdout output
    - TestSetLogger - global logger assignment
  4. internal/anchore/anchoreclient_test.go - 3 new test cases
    - TestAPIClientError_Error - basic, with API details, with controller details