### PR TITLE
ci: grant security-events write permission to CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,6 +13,8 @@ on:
 
 permissions:
   contents: read
+  security-events: write
+  actions: read
 
 jobs:
   analyze:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,15 +48,26 @@ jobs:
           checkName: "Tests (1.26.X, ubuntu-latest)"
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
+      - name: Check CodeQL analysis results
+        uses: fountainhead/action-wait-for-check@5a908a24814494009c4bb27c242ea38c93c593be #v1.2.0
+        id: codeql
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          # This check name is defined as the github actions job name + matrix language (in .github/workflows/codeql-analysis.yml)
+          checkName: "Analyze (go)"
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
       - name: Quality gate
-        if: steps.static-analysis.outputs.conclusion != 'success' || steps.tests-unit-int.outputs.conclusion != 'success'
+        if: steps.static-analysis.outputs.conclusion != 'success' || steps.tests-unit-int.outputs.conclusion != 'success' || steps.codeql.outputs.conclusion != 'success'
         run: |
           echo "Static-Analysis Status : ${STEPS_STATIC_ANALYSIS_OUTPUTS_CONCLUSION}"
           echo "Unit/Integration Status : ${STEPS_TESTS_UNIT_INT_OUTPUTS_CONCLUSION}"
+          echo "CodeQL Status : ${STEPS_CODEQL_OUTPUTS_CONCLUSION}"
           false
         env:
           STEPS_STATIC_ANALYSIS_OUTPUTS_CONCLUSION: ${{ steps.static-analysis.outputs.conclusion }}
           STEPS_TESTS_UNIT_INT_OUTPUTS_CONCLUSION: ${{ steps.tests-unit-int.outputs.conclusion }}
+          STEPS_CODEQL_OUTPUTS_CONCLUSION: ${{ steps.codeql.outputs.conclusion }}
 
   release:
     needs: [ wait-for-checks ]


### PR DESCRIPTION
looks like 2 dependabot prs conflicted once they were merged.

  The CodeQL workflow's token was scoped to `contents: read`, which
  lacks the `security-events: write` permission the analyze step needs
  to upload SARIF results. Analysis ran fine but the upload failed with
  "Resource not accessible by integration," failing the job on pushes to
  main. Add `security-events: write` (and `actions: read`, per CodeQL's
  recommendation) to restore result uploads.
