### PR TITLE
adding workflows required for automated releases of integrations

### DIFF
--- a/.github/workflows/release-integrations.yaml
+++ b/.github/workflows/release-integrations.yaml
@@ -20,6 +20,14 @@
 # that version — the commit e2e actually validated — not a possibly-advanced
 # main.
 #
+# DEPENDABOT-ONLY GUARD. This workflow may only cut dependency-bump releases:
+# every commit between the last GA release and the commit being tagged must be
+# authored by dependabot[bot]. A single human (or other) author blocks the tag.
+# The check runs against the commit we're about to tag (HEAD for an RC, the RC's
+# commit for a GA), so a human commit that lands on main *after* an RC does not
+# block promoting that already-validated RC — only what's actually in the
+# release matters.
+#
 # The GA stage is dispatched by the platform-int-releaser Lambda by filename, so
 # this file's name MUST match circleci_config.ga_workflow in webhooks.yaml
 # (release-integrations.yaml). It declares a single `version` input — the only
@@ -67,9 +75,9 @@ jobs:
           fi
           echo "TAG_TOKEN present."
 
-      - name: Push tag
+      - name: Resolve target commit and enforce dependabot-only changes
+        id: plan
         env:
-          TAG_TOKEN: ${{ secrets.TAG_TOKEN }}
           VERSION: ${{ inputs.version }}
         run: |
           set -eu
@@ -79,8 +87,8 @@ jobs:
           case "$TAG" in
             *-rc*)
               # RC: cut from the currently checked-out ref (main HEAD).
-              echo "tagging RC $TAG at HEAD"
-              git tag "$TAG"
+              TARGET_SHA=$(git rev-parse HEAD)
+              echo "RC $TAG → tag HEAD ($TARGET_SHA)"
               ;;
             *)
               # GA: tag the SAME commit as the latest RC of this version. main
@@ -94,13 +102,48 @@ jobs:
                 echo "no ${TAG}-rcN tag found; refusing to cut GA from an untested commit" >&2
                 exit 1
               fi
-              RC_SHA=$(git rev-list -n1 "$LATEST_RC")
-              echo "tagging GA $TAG at $LATEST_RC ($RC_SHA)"
-              git tag "$TAG" "$RC_SHA"
+              TARGET_SHA=$(git rev-list -n1 "$LATEST_RC")
+              echo "GA $TAG → tag $LATEST_RC ($TARGET_SHA)"
               ;;
           esac
 
-          echo "pushing $TAG"
+          # Guard: only dependency-bump releases may be tagged by this workflow.
+          # Baseline is the last GA tag (v<semver> with no prerelease suffix);
+          # every commit from there to the commit we're about to tag must be
+          # authored by dependabot[bot]. --no-merges: a squash/merge commit's
+          # committer (web-flow or whoever clicked merge) is irrelevant — we only
+          # judge who authored the actual changes.
+          BASE=$(git tag -l 'v[0-9]*' | awk '!/-/' | sort -V | tail -n1)
+          if [ -z "$BASE" ]; then
+            echo "::error::no prior GA release tag to compare against; cut the first release manually." >&2
+            exit 1
+          fi
+          echo "checking authors of ${BASE}..${TARGET_SHA}"
+
+          NON_DEP=$(git log --no-merges --format='%an' "${BASE}..${TARGET_SHA}" | grep -cxvF 'dependabot[bot]' || true)
+          if [ "${NON_DEP:-0}" -ne 0 ]; then
+            echo "::error::${NON_DEP} non-dependabot commit(s) since ${BASE} — refusing to auto-release (this workflow only tags dependency-bump releases)." >&2
+            echo "non-dependabot commits:" >&2
+            git log --no-merges --format='  %h  %an  %s' "${BASE}..${TARGET_SHA}" | grep -vF 'dependabot[bot]' >&2 || true
+            exit 1
+          fi
+          echo "all changes since ${BASE} are from dependabot[bot] — ok to tag ${TAG}."
+
+          {
+            echo "tag=${TAG}"
+            echo "target_sha=${TARGET_SHA}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Push tag
+        env:
+          TAG_TOKEN: ${{ secrets.TAG_TOKEN }}
+          TAG: ${{ steps.plan.outputs.tag }}
+          TARGET_SHA: ${{ steps.plan.outputs.target_sha }}
+        run: |
+          set -eu
+          echo "tagging $TAG at $TARGET_SHA and pushing"
+          git tag "$TAG" "$TARGET_SHA"
+
           # github's git endpoint rejects `bearer` headers. a credential helper
           # feeds the token to git over a pipe instead — note the single quotes:
           # git stores the literal `$TAG_TOKEN`, and the helper's own shell

--- a/.github/workflows/release-integrations.yaml
+++ b/.github/workflows/release-integrations.yaml
@@ -1,0 +1,111 @@
+# Gated RC/GA tagger for k8s-inventory's automated release pipeline.
+#
+# One workflow, two stages, keyed on the version string:
+#   -rc version  → pins the `rc-release` environment
+#   bare version → pins the `ga-release` environment
+# Each environment is gated by the platform-int-releaser GitHub App (attached as
+# a custom deployment protection rule). GitHub parks the deployment; the Lambda
+# evaluates policy, mints a repo-scoped contents:write token, writes it as the
+# TAG_TOKEN env secret, and approves the gate. This workflow then pushes the tag.
+#
+# TAG-ONLY BY DESIGN. It does NOT build artifacts or create the GitHub Release.
+# Pushing the v* tag triggers the existing release.yaml (goreleaser), which
+# builds + pushes the images and creates the Release (`prerelease: auto` marks
+# RCs). That Release event is what drives the rest of the pipeline —
+# release.prereleased → e2e (trigger-circleci-e2e.yaml); release.published (GA)
+# → downstream fan-out. Creating a release here too would collide with
+# goreleaser, so we deliberately stop at the tag push.
+#
+# RC is cut from main HEAD; GA is cut from the SAME commit as the latest RC of
+# that version — the commit e2e actually validated — not a possibly-advanced
+# main.
+#
+# The GA stage is dispatched by the platform-int-releaser Lambda by filename, so
+# this file's name MUST match circleci_config.ga_workflow in webhooks.yaml
+# (release-integrations.yaml). It declares a single `version` input — the only
+# input the Lambda sends.
+
+name: Release Integrations
+
+permissions: {}
+
+concurrency:
+  group: release-integrations
+  cancel-in-progress: false
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: version to release, RC or GA (e.g. 1.2.3 or 1.2.3-rc1 — v prefix optional)
+        required: true
+
+run-name: release-integrations ${{ inputs.version }}
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    # each stage keeps its own gated env so the automation can apply different
+    # policy to an RC than to a GA (e.g. human reviewers on ga-release).
+    environment: ${{ contains(inputs.version, '-rc') && 'rc-release' || 'ga-release' }}
+    # No workflow-level GITHUB_TOKEN scopes: the git push uses the short-lived
+    # TAG_TOKEN minted by the release automation, not the workflow token.
+    permissions: {}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify TAG_TOKEN was minted
+        env:
+          TAG_TOKEN: ${{ secrets.TAG_TOKEN }}
+        run: |
+          if [ -z "${TAG_TOKEN:-}" ]; then
+            echo "TAG_TOKEN not set — the env gate should have written it as an env secret." >&2
+            exit 1
+          fi
+          echo "TAG_TOKEN present."
+
+      - name: Push tag
+        env:
+          TAG_TOKEN: ${{ secrets.TAG_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -eu
+          # tolerate both `1.2.3` and `v1.2.3` inputs
+          TAG="v${VERSION#v}"
+
+          case "$TAG" in
+            *-rc*)
+              # RC: cut from the currently checked-out ref (main HEAD).
+              echo "tagging RC $TAG at HEAD"
+              git tag "$TAG"
+              ;;
+            *)
+              # GA: tag the SAME commit as the latest RC of this version. main
+              # may have advanced since that RC was cut and e2e-tested, so the GA
+              # must point at exactly the commit that was validated — not HEAD.
+              # fetch-depth: 0 makes every RC tag + its commit available locally.
+              # sort -V orders rc2 < rc10 correctly; the glob won't match other
+              # versions (e.g. v1.2.30-rc1) since the next char after $TAG is '-'.
+              LATEST_RC=$(git tag -l "${TAG}-rc*" | sort -V | tail -n1)
+              if [ -z "$LATEST_RC" ]; then
+                echo "no ${TAG}-rcN tag found; refusing to cut GA from an untested commit" >&2
+                exit 1
+              fi
+              RC_SHA=$(git rev-list -n1 "$LATEST_RC")
+              echo "tagging GA $TAG at $LATEST_RC ($RC_SHA)"
+              git tag "$TAG" "$RC_SHA"
+              ;;
+          esac
+
+          echo "pushing $TAG"
+          # github's git endpoint rejects `bearer` headers. a credential helper
+          # feeds the token to git over a pipe instead — note the single quotes:
+          # git stores the literal `$TAG_TOKEN`, and the helper's own shell
+          # expands it from the env at push time, so the value never lands in
+          # argv or in .git/config.
+          git -c credential.helper= \
+              -c credential.helper='!f() { echo username=x-access-token; echo "password=$TAG_TOKEN"; }; f' \
+              push origin "$TAG"

--- a/.github/workflows/trigger-circleci-e2e.yaml
+++ b/.github/workflows/trigger-circleci-e2e.yaml
@@ -13,6 +13,16 @@
 #     API to recover which product/RC a completed run tested — the native
 #     workflow-completed webhook does not carry pipeline parameters.
 #
+# GA-PROMOTION GATE. A successful e2e run drives a GA tag ONLY when this workflow
+# sends the CALLBACK_* params (that pair is what the Lambda dispatches GA from).
+#   - Automatic `release.prereleased` runs always send them — that's the pipeline.
+#   - MANUAL (workflow_dispatch) runs are TEST-ONLY by default: they omit
+#     CALLBACK_*, so e2e runs but the callback sees no product/RC and skips the
+#     GA dispatch. To deliberately promote via a manual run, set promote=true.
+# This keeps a casual "re-run e2e" from cutting a GA. (Even a promoting run still
+# has to clear the ga-release environment's required reviewers downstream — this
+# gate is the first line, not the only one.)
+#
 # ┌─ REQUIRED on the CircleCI project side ────────────────────────────────────┐
 # │ The project's setup config AND its continuation config must DECLARE the     │
 # │ CALLBACK_PRODUCT_REPO and CALLBACK_RC_TAG string parameters (default "").   │
@@ -20,10 +30,6 @@
 # │ without this the POST below 400s. They need only be declared (so the Lambda │
 # │ can read them back); no job has to consume them.                            │
 # └─────────────────────────────────────────────────────────────────────────────┘
-#
-# `prereleased` fires only for releases with the pre-release box checked
-# (goreleaser's `prerelease: auto` sets it for RC tags), so GA releases never
-# trigger this. The explicit `if` below is belt-and-suspenders.
 #
 # Config (all live in the `e2e` environment):
 #   - secrets.CIRCLECI_API_TOKEN      CircleCI token able to trigger the e2e
@@ -47,6 +53,10 @@ on:
       tag:
         description: RC tag to run the e2e pipeline for (e.g. v1.2.3-rc1)
         required: true
+      promote:
+        description: "if e2e passes, ALSO allow promotion to GA (default off — manual runs are test-only)"
+        type: boolean
+        default: false
 
 jobs:
   trigger:
@@ -63,32 +73,47 @@ jobs:
           PROJECT_SLUG: ${{ secrets.CIRCLECI_PROJECT_SLUG }}
           E2E_BRANCH: ${{ vars.CIRCLECI_E2E_BRANCH || 'main' }}
           PRODUCT_REPO: ${{ github.repository }}
+          EVENT: ${{ github.event_name }}
           # release events carry tag_name; manual runs supply it via input.
           RC_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          # only meaningful on manual runs; empty on release events.
+          PROMOTE_INPUT: ${{ inputs.promote }}
         run: |
           set -eu
           : "${CIRCLECI_API_TOKEN:?secret not set}"
           : "${PROJECT_SLUG:?secret not set}"
 
+          # RC-tag shape check: reject anything that isn't vX.Y.Z-rcN before we
+          # trigger. Belt-and-suspenders — the Lambda re-validates this and the
+          # GA tagger additionally requires the RC tag to actually exist.
+          case "$RC_TAG" in
+            v[0-9]*.[0-9]*.[0-9]*-rc[0-9]*) : ;;
+            *) echo "refusing: '$RC_TAG' is not an RC tag (expected vX.Y.Z-rcN)" >&2; exit 1 ;;
+          esac
+
+          # GA-promotion gate: automatic pre-release events always promote; a
+          # manual run only promotes when the operator opts in with promote=true.
+          if [ "$EVENT" = "release" ] || [ "${PROMOTE_INPUT:-false}" = "true" ]; then
+            PROMOTE=true
+          else
+            PROMOTE=false
+          fi
+          echo "event=$EVENT  promote=$PROMOTE  rc_tag=$RC_TAG"
+
+          # Base params always run the k8s suite against this RC's image. A
+          # promoting run additionally carries the CALLBACK_* pair the Lambda
+          # dispatches GA from; a test-only run omits it and therefore CANNOT
+          # cut a GA (the callback sees no product/RC → log-only skip).
+          PARAMS=$(jq -cn --arg tag "$RC_TAG" '{RUN_K8S_SUITE: true, TAG_K8S_INVENTORY: $tag}')
+          if [ "$PROMOTE" = "true" ]; then
+            PARAMS=$(printf '%s' "$PARAMS" | jq -c \
+              --arg repo "$PRODUCT_REPO" --arg tag "$RC_TAG" \
+              '. + {CALLBACK_PRODUCT_REPO: $repo, CALLBACK_RC_TAG: $tag}')
+          fi
+
           # Trigger by BRANCH, not tag: the RC tag lives on k8s-inventory, not on
-          # the e2e project's repo. The product repo + RC tag ride along as
-          # pipeline parameters instead (the CALLBACK_* pair the Lambda reads
-          # back).
-          #
-          # RUN_K8S_SUITE=true selects the k8s-inventory suite in the e2e
-          # project's setup config; TAG_K8S_INVENTORY pins it to this RC's
-          # published image (goreleaser pushes anchore/k8s-inventory:<tag> for
-          # prereleases).
-          BODY=$(jq -cn \
-            --arg br   "$E2E_BRANCH" \
-            --arg repo "$PRODUCT_REPO" \
-            --arg tag  "$RC_TAG" \
-            '{branch:$br, parameters:{
-                CALLBACK_PRODUCT_REPO: $repo,
-                CALLBACK_RC_TAG:       $tag,
-                RUN_K8S_SUITE:         true,
-                TAG_K8S_INVENTORY:     $tag
-             }}')
+          # the e2e project's repo.
+          BODY=$(jq -cn --arg br "$E2E_BRANCH" --argjson p "$PARAMS" '{branch: $br, parameters: $p}')
 
           # -f makes the step fail on any 4xx/5xx from the API (e.g. an
           # undeclared-parameter 400 → see the required declaration above).

--- a/.github/workflows/trigger-circleci-e2e.yaml
+++ b/.github/workflows/trigger-circleci-e2e.yaml
@@ -1,0 +1,99 @@
+# Triggers the downstream CircleCI e2e pipeline when a k8s-inventory
+# *pre-release* (RC) is published, so the RC image gets exercised end-to-end
+# before it is promoted to GA.
+#
+# The e2e pipeline lives in a *separate, private* CircleCI project (its repo is
+# not named here — see the CIRCLECI_PROJECT_SLUG secret below). Because it's a
+# different repo from k8s-inventory:
+#   - We trigger by BRANCH, never by tag: the RC tag exists on k8s-inventory,
+#     not on the CircleCI project's repo, so a tag trigger would 404 there.
+#   - The product repo + RC tag this run is for are carried as pipeline
+#     parameters (CALLBACK_PRODUCT_REPO / CALLBACK_RC_TAG). The
+#     platform-int-releaser Lambda reads them back via CircleCI's pipeline-values
+#     API to recover which product/RC a completed run tested — the native
+#     workflow-completed webhook does not carry pipeline parameters.
+#
+# ┌─ REQUIRED on the CircleCI project side ────────────────────────────────────┐
+# │ The project's setup config AND its continuation config must DECLARE the     │
+# │ CALLBACK_PRODUCT_REPO and CALLBACK_RC_TAG string parameters (default "").   │
+# │ CircleCI rejects a trigger that sets undeclared pipeline parameters, so     │
+# │ without this the POST below 400s. They need only be declared (so the Lambda │
+# │ can read them back); no job has to consume them.                            │
+# └─────────────────────────────────────────────────────────────────────────────┘
+#
+# `prereleased` fires only for releases with the pre-release box checked
+# (goreleaser's `prerelease: auto` sets it for RC tags), so GA releases never
+# trigger this. The explicit `if` below is belt-and-suspenders.
+#
+# Config (all live in the `e2e` environment):
+#   - secrets.CIRCLECI_API_TOKEN      CircleCI token able to trigger the e2e
+#                                     project's pipelines (Circle-Token)
+#   - secrets.CIRCLECI_PROJECT_SLUG   the e2e project slug, e.g. gh/<org>/<repo>.
+#                                     A secret (not a var) so the private repo
+#                                     name is masked in logs, not just kept out
+#                                     of source.
+#   - vars.CIRCLECI_E2E_BRANCH        branch of the e2e project to run
+#                                     (defaults to main; not sensitive)
+
+name: Trigger CircleCI e2e
+
+permissions: {}
+
+on:
+  release:
+    types: [prereleased]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: RC tag to run the e2e pipeline for (e.g. v1.2.3-rc1)
+        required: true
+
+jobs:
+  trigger:
+    # Run for manual dispatches, or for release events only when the release is
+    # actually a pre-release.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.release.prerelease == true }}
+    runs-on: ubuntu-24.04
+    environment: e2e
+    permissions: {}
+    steps:
+      - name: Trigger e2e pipeline for the RC
+        env:
+          CIRCLECI_API_TOKEN: ${{ secrets.CIRCLECI_API_TOKEN }}
+          PROJECT_SLUG: ${{ secrets.CIRCLECI_PROJECT_SLUG }}
+          E2E_BRANCH: ${{ vars.CIRCLECI_E2E_BRANCH || 'main' }}
+          PRODUCT_REPO: ${{ github.repository }}
+          # release events carry tag_name; manual runs supply it via input.
+          RC_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+        run: |
+          set -eu
+          : "${CIRCLECI_API_TOKEN:?secret not set}"
+          : "${PROJECT_SLUG:?secret not set}"
+
+          # Trigger by BRANCH, not tag: the RC tag lives on k8s-inventory, not on
+          # the e2e project's repo. The product repo + RC tag ride along as
+          # pipeline parameters instead (the CALLBACK_* pair the Lambda reads
+          # back).
+          #
+          # RUN_K8S_SUITE=true selects the k8s-inventory suite in the e2e
+          # project's setup config; TAG_K8S_INVENTORY pins it to this RC's
+          # published image (goreleaser pushes anchore/k8s-inventory:<tag> for
+          # prereleases).
+          BODY=$(jq -cn \
+            --arg br   "$E2E_BRANCH" \
+            --arg repo "$PRODUCT_REPO" \
+            --arg tag  "$RC_TAG" \
+            '{branch:$br, parameters:{
+                CALLBACK_PRODUCT_REPO: $repo,
+                CALLBACK_RC_TAG:       $tag,
+                RUN_K8S_SUITE:         true,
+                TAG_K8S_INVENTORY:     $tag
+             }}')
+
+          # -f makes the step fail on any 4xx/5xx from the API (e.g. an
+          # undeclared-parameter 400 → see the required declaration above).
+          curl -fsS -X POST \
+            "https://circleci.com/api/v2/project/${PROJECT_SLUG}/pipeline" \
+            -H "Circle-Token: ${CIRCLECI_API_TOKEN}" \
+            -H "content-type: application/json" \
+            --data "$BODY"


### PR DESCRIPTION
Adding two workflows:
1. cuts a rc/ga tag
2. triggers e2es