### PR TITLE
feat(inventory): collect inventory from the Kubernetes event stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,12 @@ kubernetes:
   worker-pool-size: 100
 ```
 
+`request-batch-size` and `worker-pool-size` only apply to the `poll` inventory
+collection method - the informers page and dispatch their own work.
+`request-timeout-seconds` still bounds the individual requests the agent makes
+outside of the informers; see `inventory-collection.informer.cache-sync-timeout-seconds`
+for the informer startup deadline.
+
 ### anchore-k8s-inventory mode of operation
 
 ```yaml
@@ -401,6 +407,97 @@ mode: adhoc
 # Only respected if mode is periodic
 polling-interval-seconds: 300
 ```
+
+### Inventory collection
+
+When running in `periodic` mode, `anchore-k8s-inventory` collects the inventory
+by watching the Kubernetes event stream (using
+[informers](https://pkg.go.dev/k8s.io/client-go/informers)) rather than listing
+the whole cluster from the api-server on every polling interval. This means:
+
+* Pods and containers that are created *and* deleted in between two reports are
+  still included in the next report, instead of being missed entirely.
+* The api-server is not asked for a full listing of every namespace, pod and
+  node on each interval, which noticeably reduces its load on large clusters.
+
+Anything deleted since the previous report is buffered by the agent and included
+in the next one, so short lived containers are recorded in Anchore with a
+`last_seen` timestamp of that report. Note that this means reports can be larger
+than they were with the previous polling behaviour.
+
+There are two trade-offs to be aware of:
+
+* The agent keeps a cache of the pods it is watching, so its memory use scales
+  with the size of that cache rather than with the reporting interval.
+* Unless exactly one namespace is configured in `namespace-selectors.include`
+  (in which case the agent watches only that namespace), the agent watches pods
+  cluster-wide and discards the ones the selectors reject when it builds the
+  report. If you scope the agent to a handful of namespaces on a large cluster,
+  `method: poll` may still use less memory, since it only ever lists the
+  namespaces it reports on.
+
+The previous behaviour is still available by setting the collection method to
+`poll`:
+
+```yaml
+# How inventory is collected from the cluster. Only respected if mode is
+# periodic, adhoc mode always collects inventory by polling.
+inventory-collection:
+  # One of the following options [informer, poll]. Default is 'informer'
+  #
+  # [informer] watches the kubernetes event stream so that pods and containers
+  #            that are created and deleted between two reports are still
+  #            reported, and so that the api-server is not asked to list the
+  #            whole cluster on every polling interval.
+  #
+  # [poll] lists every namespace, pod and node from the api-server on each
+  #        polling interval. This is the behaviour of releases before the
+  #        informer method was introduced. Resources that come and go between
+  #        two polls are not reported.
+  method: informer
+
+  # Tuning options for the informer collection method
+  informer:
+    # How long to wait on startup for the initial listing of the cluster to
+    # complete. This listing covers every pod in the cluster, so it needs to be
+    # more generous than kubernetes.request-timeout-seconds, which bounds a
+    # single api-server request. Set to 0 to wait for as long as it takes.
+    cache-sync-timeout-seconds: 300
+```
+
+or via the equivalent environment variable:
+
+```sh
+ANCHORE_K8S_INVENTORY_INVENTORY_COLLECTION_METHOD=poll
+```
+
+Watching the event stream requires the `watch` verb, in addition to `get` and
+`list`, on `pods`, `namespaces` and `nodes`. The ClusterRole in the
+[Helm chart](https://github.com/anchore/anchore-charts/tree/main/stable/k8s-inventory)
+already grants these; if you are deploying with your own RBAC, make sure the
+agent's role does too. Scoping the agent with a namespaced `Role` instead of a
+ClusterRole is not enough for this collection method, because the namespace and
+node informers are cluster-scoped.
+
+As with the polling collection method, not being permitted to read nodes is
+tolerated - a warning is logged and node inventory is not collected.
+
+The informers are started in the background, so the agent polls the api-server
+for inventory until their caches have filled and then switches over. Reporting
+is never held up waiting for them. If they cannot be started at all - RBAC, an
+unreachable api-server, or an initial listing that takes longer than
+`cache-sync-timeout-seconds` - the agent logs a warning, carries on polling, and
+retries in the background after a delay that grows with each consecutive
+failure, from one minute up to one hour. A cluster the agent is not allowed to
+watch therefore settles into steady polling rather than retrying on every
+report.
+
+One case the agent cannot currently detect: if it is allowed to `list` pods but
+not to `watch` them, the caches fill successfully and the agent reports
+inventory that looks correct, but it captures no transient pods and re-lists the
+cluster far more often than the `poll` method would. Grant `watch` alongside
+`list`, or set `method: poll`, rather than relying on the fallback to catch
+this.
 
 ### Missing Tag Policy
 

--- a/anchore-k8s-inventory.yaml
+++ b/anchore-k8s-inventory.yaml
@@ -128,6 +128,32 @@ ignore-not-running: true
 # Only respected if mode is periodic
 polling-interval-seconds: 300
 
+# How inventory is collected from the cluster. Only respected if mode is
+# periodic, adhoc mode always collects inventory by polling.
+inventory-collection:
+  # One of the following options [informer, poll]. Default is 'informer'
+  #
+  # [informer] watches the kubernetes event stream so that pods and containers
+  #            that are created and deleted between two reports are still
+  #            reported, and so that the api-server is not asked to list the
+  #            whole cluster on every polling interval.
+  #
+  # [poll] lists every namespace, pod and node from the api-server on each
+  #        polling interval. This is the behaviour of releases before the
+  #        informer method was introduced. Resources that come and go between
+  #        two polls are not reported.
+  method: informer
+
+  # Tuning options for the informer collection method
+  informer:
+    # How long to wait on startup for the initial listing of the cluster to
+    # complete. This listing covers every pod in the cluster, so it needs to be
+    # more generous than kubernetes.request-timeout-seconds, which bounds a
+    # single api-server request. Set to 0 to wait for as long as it takes.
+    # The agent polls for inventory while the caches are filling, so exceeding
+    # this does not stop reporting.
+    cache-sync-timeout-seconds: 300
+
 # Only respected if mode is periodic
 health-report-interval-seconds: 60
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,6 +58,7 @@ type Application struct {
 	HealthReportIntervalSeconds     int                   `mapstructure:"health-report-interval-seconds" json:"health-report-interval-seconds,omitempty" yaml:"health-report-interval-seconds"`
 	InventoryReportLimits           InventoryReportLimits `mapstructure:"inventory-report-limits" json:"inventory-report-limits,omitempty" yaml:"inventory-report-limits"`
 	MetadataCollection              MetadataCollection    `mapstructure:"metadata-collection" json:"metadata-collection,omitempty" yaml:"metadata-collection"`
+	InventoryCollection             InventoryCollection   `mapstructure:"inventory-collection" json:"inventory-collection,omitempty" yaml:"inventory-collection"`
 	AnchoreDetails                  AnchoreInfo           `mapstructure:"anchore" json:"anchore,omitempty" yaml:"anchore"`
 	VerboseInventoryReports         bool                  `mapstructure:"verbose-inventory-reports" json:"verbose-inventory-reports,omitempty" yaml:"verbose-inventory-reports"`
 }
@@ -120,6 +121,29 @@ type MetadataCollection struct {
 	Pods      ResourceMetadata `mapstructure:"pods" json:"pods,omitempty" yaml:"pods"`
 }
 
+// Inventory collection methods. "informer" watches the Kubernetes event stream
+// so that resources that come and go between reports are still reported.
+// "poll" is the legacy behaviour of listing the whole cluster every interval.
+const (
+	InventoryCollectionMethodInformer = "informer"
+	InventoryCollectionMethodPoll     = "poll"
+)
+
+// InventoryCollection details how inventory is gathered from the cluster when
+// running in periodic mode. Adhoc mode always uses the poll method.
+type InventoryCollection struct {
+	Method   string   `mapstructure:"method" json:"method,omitempty" yaml:"method"`
+	Informer Informer `mapstructure:"informer" json:"informer,omitempty" yaml:"informer"`
+}
+
+// Informer details the tuning options for the informer collection method
+type Informer struct {
+	// How long to wait for the informer caches to fill on startup. The initial
+	// listing covers the whole cluster, so this needs to be more generous than
+	// the timeout for an individual api-server request. 0 waits indefinitely.
+	CacheSyncTimeoutSeconds int `mapstructure:"cache-sync-timeout-seconds" json:"cache-sync-timeout-seconds,omitempty" yaml:"cache-sync-timeout-seconds"`
+}
+
 // Information for posting in-use image details to Anchore (or any URL for that matter)
 type AnchoreInfo struct {
 	URL      string     `mapstructure:"url" json:"url,omitempty" yaml:"url"`
@@ -179,6 +203,8 @@ func setNonCliDefaultValues(v *viper.Viper) {
 	v.SetDefault("namespace-selectors.include", []string{})
 	v.SetDefault("namespace-selectors.exclude", []string{})
 	v.SetDefault("namespace-selectors.ignore-empty", false)
+	v.SetDefault("inventory-collection.method", InventoryCollectionMethodInformer)
+	v.SetDefault("inventory-collection.informer.cache-sync-timeout-seconds", 300)
 }
 
 // Load the Application Configuration from the Viper specifications
@@ -268,6 +294,30 @@ func (cfg *Application) Build() error {
 
 	if cfg.HealthReportIntervalSeconds < 30 || cfg.HealthReportIntervalSeconds > 600 {
 		return fmt.Errorf("health-report-interval-seconds must be between 30 and 600")
+	}
+
+	if err := cfg.InventoryCollection.validate(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (ic *InventoryCollection) validate() error {
+	methods := []string{InventoryCollectionMethodInformer, InventoryCollectionMethodPoll}
+	validMethod := false
+	for _, m := range methods {
+		if ic.Method == m {
+			validMethod = true
+			break
+		}
+	}
+	if !validMethod {
+		return fmt.Errorf("inventory-collection.method must be one of %v", methods)
+	}
+
+	if ic.Informer.CacheSyncTimeoutSeconds < 0 {
+		return fmt.Errorf("inventory-collection.informer.cache-sync-timeout-seconds must not be negative")
 	}
 
 	return nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -170,3 +170,71 @@ func TestSensitiveConfigJSON(t *testing.T) {
 		t.Errorf("Config string does not match expected\nactual: %s\nexpected: %s", actual, expected)
 	}
 }
+
+func TestInventoryCollection_validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  InventoryCollection
+		wantErr bool
+	}{
+		{
+			name:   "informer is a valid method",
+			config: InventoryCollection{Method: InventoryCollectionMethodInformer, Informer: Informer{CacheSyncTimeoutSeconds: 300}},
+		},
+		{
+			name:   "poll is a valid method",
+			config: InventoryCollection{Method: InventoryCollectionMethodPoll},
+		},
+		{
+			name:   "a cache sync timeout of zero waits indefinitely",
+			config: InventoryCollection{Method: InventoryCollectionMethodInformer, Informer: Informer{CacheSyncTimeoutSeconds: 0}},
+		},
+		{
+			name:    "a negative cache sync timeout is rejected",
+			config:  InventoryCollection{Method: InventoryCollectionMethodInformer, Informer: Informer{CacheSyncTimeoutSeconds: -1}},
+			wantErr: true,
+		},
+		{
+			name:    "an unknown method is rejected",
+			config:  InventoryCollection{Method: "watch"},
+			wantErr: true,
+		},
+		{
+			name:    "an unset method is rejected",
+			config:  InventoryCollection{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected an error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestDefaultInventoryCollection(t *testing.T) {
+	config, err := LoadConfigFromFile(viper.New(), &CliOnlyOptions{
+		ConfigPath: "../../anchore-k8s-inventory.yaml",
+	})
+	if err != nil {
+		t.Fatalf("failed to load application config: \n\t%+v\n", err)
+	}
+
+	if config.InventoryCollection.Method != InventoryCollectionMethodInformer {
+		t.Errorf("expected the default collection method to be %q, got %q",
+			InventoryCollectionMethodInformer, config.InventoryCollection.Method)
+	}
+	if config.InventoryCollection.Informer.CacheSyncTimeoutSeconds != 300 {
+		t.Errorf("expected the default cache sync timeout to be 300, got %d",
+			config.InventoryCollection.Informer.CacheSyncTimeoutSeconds)
+	}
+}

--- a/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
@@ -65,6 +65,10 @@ metadata-collection:
     include-annotations: []
     include-labels: []
     disable: false
+inventory-collection:
+  method: informer
+  informer:
+    cache-sync-timeout-seconds: 300
 anchore:
   url: ""
   user: ""

--- a/internal/config/test-fixtures/snapshot/TestEmptyConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestEmptyConfigString.golden
@@ -65,6 +65,10 @@ metadata-collection:
     include-annotations: []
     include-labels: []
     disable: false
+inventory-collection:
+  method: ""
+  informer:
+    cache-sync-timeout-seconds: 0
 anchore:
   url: ""
   user: ""

--- a/internal/config/test-fixtures/snapshot/TestSensitiveConfigJSON.golden
+++ b/internal/config/test-fixtures/snapshot/TestSensitiveConfigJSON.golden
@@ -5,8 +5,7 @@
         "level": "debug",
         "file": "./anchore-k8s-inventory.log"
     },
-    "anchore-registration": {
-    },
+    "anchore-registration": {},
     "CliOptions": {
         "ConfigPath": "../../anchore-k8s-inventory.yaml",
         "Verbosity": 0
@@ -58,6 +57,12 @@
         "nodes": {},
         "namespace": {},
         "pods": {}
+    },
+    "inventory-collection": {
+        "method": "informer",
+        "informer": {
+            "cache-sync-timeout-seconds": 300
+        }
     },
     "anchore": {
         "password": "******",

--- a/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
@@ -75,6 +75,10 @@ metadata-collection:
     include-annotations: []
     include-labels: []
     disable: false
+inventory-collection:
+  method: informer
+  informer:
+    cache-sync-timeout-seconds: 300
 anchore:
   url: ""
   user: ""

--- a/pkg/inventory/converters_test.go
+++ b/pkg/inventory/converters_test.go
@@ -1,0 +1,227 @@
+package inventory
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNamespaceFilter_Keep(t *testing.T) {
+	type args struct {
+		excludes []string
+		includes []string
+	}
+	tests := []struct {
+		name      string
+		args      args
+		namespace string
+		want      bool
+	}{
+		{
+			name:      "no selectors keeps everything",
+			args:      args{},
+			namespace: "default",
+			want:      true,
+		},
+		{
+			name:      "explicit exclude drops the namespace",
+			args:      args{excludes: []string{"default"}},
+			namespace: "default",
+			want:      false,
+		},
+		{
+			name:      "explicit exclude leaves other namespaces alone",
+			args:      args{excludes: []string{"default"}},
+			namespace: "kube-system",
+			want:      true,
+		},
+		{
+			name:      "regex exclude drops matching namespaces",
+			args:      args{excludes: []string{"^kube-*"}},
+			namespace: "kube-system",
+			want:      false,
+		},
+		{
+			name:      "include acts as an allow-list",
+			args:      args{includes: []string{"default"}},
+			namespace: "default",
+			want:      true,
+		},
+		{
+			name:      "namespaces outside the allow-list are dropped",
+			args:      args{includes: []string{"default"}},
+			namespace: "kube-system",
+			want:      false,
+		},
+		{
+			name:      "exclude takes precedence over include",
+			args:      args{excludes: []string{"default"}, includes: []string{"default"}},
+			namespace: "default",
+			want:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter := NewNamespaceFilter(tt.args.excludes, tt.args.includes)
+			assert.Equal(t, tt.want, filter.Keep(tt.namespace))
+		})
+	}
+}
+
+func TestNamespaceFromV1(t *testing.T) {
+	namespace := &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-namespace",
+			UID:  "namespace-uid",
+			Annotations: map[string]string{
+				"anchore.io/annotation": "annotation-value",
+				"other":                 "other-value",
+			},
+			Labels: map[string]string{
+				"anchore.io/label": "label-value",
+				"other":            "other-value",
+			},
+		},
+	}
+
+	tests := []struct {
+		name               string
+		includeAnnotations []string
+		includeLabels      []string
+		disableMetadata    bool
+		want               Namespace
+	}{
+		{
+			name: "all metadata is collected by default",
+			want: Namespace{
+				Name: "test-namespace",
+				UID:  "namespace-uid",
+				Annotations: map[string]string{
+					"anchore.io/annotation": "annotation-value",
+					"other":                 "other-value",
+				},
+				Labels: map[string]string{
+					"anchore.io/label": "label-value",
+					"other":            "other-value",
+				},
+			},
+		},
+		{
+			name:               "metadata is filtered by the include lists",
+			includeAnnotations: []string{"anchore.io/.*"},
+			includeLabels:      []string{"anchore.io/.*"},
+			want: Namespace{
+				Name:        "test-namespace",
+				UID:         "namespace-uid",
+				Annotations: map[string]string{"anchore.io/annotation": "annotation-value"},
+				Labels:      map[string]string{"anchore.io/label": "label-value"},
+			},
+		},
+		{
+			name:            "metadata collection can be disabled",
+			disableMetadata: true,
+			want: Namespace{
+				Name: "test-namespace",
+				UID:  "namespace-uid",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NamespaceFromV1(namespace, tt.includeAnnotations, tt.includeLabels, tt.disableMetadata)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestNodeFromV1(t *testing.T) {
+	node := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-node",
+			UID:  "node-uid",
+			Annotations: map[string]string{
+				"anchore.io/annotation": "annotation-value",
+				"other":                 "other-value",
+			},
+			Labels: map[string]string{
+				"anchore.io/label": "label-value",
+				"other":            "other-value",
+			},
+		},
+		Status: v1.NodeStatus{
+			NodeInfo: v1.NodeSystemInfo{
+				Architecture:            "amd64",
+				ContainerRuntimeVersion: "containerd://1.7.0",
+				KernelVersion:           "5.15.0",
+				KubeletVersion:          "v1.30.0",
+				OperatingSystem:         "linux",
+			},
+		},
+	}
+
+	tests := []struct {
+		name               string
+		includeAnnotations []string
+		includeLabels      []string
+		disableMetadata    bool
+		want               Node
+	}{
+		{
+			name: "all metadata is collected by default",
+			want: Node{
+				Name:                    "test-node",
+				UID:                     "node-uid",
+				Arch:                    "amd64",
+				ContainerRuntimeVersion: "containerd://1.7.0",
+				KernelVersion:           "5.15.0",
+				KubeletVersion:          "v1.30.0",
+				OperatingSystem:         "linux",
+				Annotations: map[string]string{
+					"anchore.io/annotation": "annotation-value",
+					"other":                 "other-value",
+				},
+				Labels: map[string]string{
+					"anchore.io/label": "label-value",
+					"other":            "other-value",
+				},
+			},
+		},
+		{
+			name:               "metadata is filtered by the include lists",
+			includeAnnotations: []string{"anchore.io/.*"},
+			includeLabels:      []string{"anchore.io/.*"},
+			want: Node{
+				Name:                    "test-node",
+				UID:                     "node-uid",
+				Arch:                    "amd64",
+				ContainerRuntimeVersion: "containerd://1.7.0",
+				KernelVersion:           "5.15.0",
+				KubeletVersion:          "v1.30.0",
+				OperatingSystem:         "linux",
+				Annotations:             map[string]string{"anchore.io/annotation": "annotation-value"},
+				Labels:                  map[string]string{"anchore.io/label": "label-value"},
+			},
+		},
+		{
+			name:            "metadata collection can be disabled",
+			disableMetadata: true,
+			want: Node{
+				Name:                    "test-node",
+				UID:                     "node-uid",
+				Arch:                    "amd64",
+				ContainerRuntimeVersion: "containerd://1.7.0",
+				KernelVersion:           "5.15.0",
+				KubeletVersion:          "v1.30.0",
+				OperatingSystem:         "linux",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NodeFromV1(node, tt.includeAnnotations, tt.includeLabels, tt.disableMetadata)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/inventory/namespace.go
+++ b/pkg/inventory/namespace.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"time"
 
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/anchore/k8s-inventory/internal/tracker"
@@ -71,6 +72,55 @@ func excludeNamespace(checks []excludeCheck, namespace string) bool {
 	return false
 }
 
+// NamespaceFilter holds the compiled include/exclude rules for namespaces so
+// that they can be built once and reused for every namespace that needs
+// checking (e.g. for each event received from an informer).
+type NamespaceFilter struct {
+	excludeChecks []excludeCheck
+	includes      map[string]struct{}
+}
+
+// NewNamespaceFilter builds a reusable filter from the configured namespace
+// selectors. When includes is non-empty it acts as an allow-list, otherwise
+// every namespace that is not excluded is kept.
+func NewNamespaceFilter(excludes, includes []string) NamespaceFilter {
+	includeSet := make(map[string]struct{}, len(includes))
+	for _, ns := range includes {
+		includeSet[ns] = struct{}{}
+	}
+
+	return NamespaceFilter{
+		excludeChecks: buildExclusionChecklist(excludes),
+		includes:      includeSet,
+	}
+}
+
+// Keep reports whether the named namespace should be part of the inventory
+func (f NamespaceFilter) Keep(namespace string) bool {
+	if excludeNamespace(f.excludeChecks, namespace) {
+		return false
+	}
+	if len(f.includes) > 0 {
+		_, included := f.includes[namespace]
+		return included
+	}
+	return true
+}
+
+// NamespaceFromV1 converts a kubernetes namespace into its inventory
+// representation, applying the configured metadata collection rules
+func NamespaceFromV1(n *v1.Namespace, includeAnnotations, includeLabels []string, disableMetadata bool) Namespace {
+	ns := Namespace{
+		Name: n.Name,
+		UID:  string(n.UID),
+	}
+	if !disableMetadata {
+		ns.Annotations = processAnnotationsOrLabels(n.Annotations, includeAnnotations)
+		ns.Labels = processAnnotationsOrLabels(n.Labels, includeLabels)
+	}
+	return ns
+}
+
 func FetchNamespaces(
 	c client.Client,
 	batchSize, timeout int64,
@@ -81,7 +131,7 @@ func FetchNamespaces(
 	defer tracker.TrackFunctionTime(time.Now(), "Fetching namespaces")
 	nsMap := make(map[string]Namespace)
 
-	exclusionChecklist := buildExclusionChecklist(excludes)
+	filter := NewNamespaceFilter(excludes, nil)
 
 	cont := ""
 	for {
@@ -95,24 +145,10 @@ func FetchNamespaces(
 		if err != nil {
 			return nil, fmt.Errorf("failed to list namespaces: %w", err)
 		}
-		for _, n := range list.Items {
-			if !excludeNamespace(exclusionChecklist, n.Name) {
-				if !disableMetadata {
-					annotations := processAnnotationsOrLabels(n.Annotations, includeAnnotations)
-					labels := processAnnotationsOrLabels(n.Labels, includeLabels)
-
-					nsMap[n.Name] = Namespace{
-						Name:        n.Name,
-						UID:         string(n.UID),
-						Annotations: annotations,
-						Labels:      labels,
-					}
-				} else {
-					nsMap[n.Name] = Namespace{
-						Name: n.Name,
-						UID:  string(n.UID),
-					}
-				}
+		for i := range list.Items {
+			n := &list.Items[i]
+			if filter.Keep(n.Name) {
+				nsMap[n.Name] = NamespaceFromV1(n, includeAnnotations, includeLabels, disableMetadata)
 			}
 		}
 

--- a/pkg/inventory/nodes.go
+++ b/pkg/inventory/nodes.go
@@ -4,11 +4,32 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/anchore/k8s-inventory/internal/log"
-	"github.com/anchore/k8s-inventory/pkg/client"
+	v1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/anchore/k8s-inventory/internal/log"
+	"github.com/anchore/k8s-inventory/pkg/client"
 )
+
+// NodeFromV1 converts a kubernetes node into its inventory representation,
+// applying the configured metadata collection rules
+func NodeFromV1(n *v1.Node, includeAnnotations, includeLabels []string, disableMetadata bool) Node {
+	node := Node{
+		Name:                    n.Name,
+		UID:                     string(n.UID),
+		Arch:                    n.Status.NodeInfo.Architecture,
+		ContainerRuntimeVersion: n.Status.NodeInfo.ContainerRuntimeVersion,
+		KernelVersion:           n.Status.NodeInfo.KernelVersion,
+		KubeletVersion:          n.Status.NodeInfo.KubeletVersion,
+		OperatingSystem:         n.Status.NodeInfo.OperatingSystem,
+	}
+	if !disableMetadata {
+		node.Annotations = processAnnotationsOrLabels(n.Annotations, includeAnnotations)
+		node.Labels = processAnnotationsOrLabels(n.Labels, includeLabels)
+	}
+	return node
+}
 
 func FetchNodes(c client.Client, batchSize, timeout int64, includeAnnotations, includeLabels []string, disableMetadata bool) (map[string]Node, error) {
 	nodes := make(map[string]Node)
@@ -30,32 +51,9 @@ func FetchNodes(c client.Client, batchSize, timeout int64, includeAnnotations, i
 			return nil, fmt.Errorf("failed to list nodes: %w", err)
 		}
 
-		for _, n := range list.Items {
-			if !disableMetadata {
-				annotations := processAnnotationsOrLabels(n.Annotations, includeAnnotations)
-				labels := processAnnotationsOrLabels(n.Labels, includeLabels)
-				nodes[n.Name] = Node{
-					Name:                    n.Name,
-					UID:                     string(n.UID),
-					Annotations:             annotations,
-					Arch:                    n.Status.NodeInfo.Architecture,
-					ContainerRuntimeVersion: n.Status.NodeInfo.ContainerRuntimeVersion,
-					KernelVersion:           n.Status.NodeInfo.KernelVersion,
-					KubeletVersion:          n.Status.NodeInfo.KubeletVersion,
-					Labels:                  labels,
-					OperatingSystem:         n.Status.NodeInfo.OperatingSystem,
-				}
-			} else {
-				nodes[n.Name] = Node{
-					Name:                    n.Name,
-					UID:                     string(n.UID),
-					Arch:                    n.Status.NodeInfo.Architecture,
-					ContainerRuntimeVersion: n.Status.NodeInfo.ContainerRuntimeVersion,
-					KernelVersion:           n.Status.NodeInfo.KernelVersion,
-					KubeletVersion:          n.Status.NodeInfo.KubeletVersion,
-					OperatingSystem:         n.Status.NodeInfo.OperatingSystem,
-				}
-			}
+		for i := range list.Items {
+			n := &list.Items[i]
+			nodes[n.Name] = NodeFromV1(n, includeAnnotations, includeLabels, disableMetadata)
 		}
 
 		cont = list.GetListMeta().GetContinue()

--- a/pkg/lib.go
+++ b/pkg/lib.go
@@ -9,11 +9,14 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sync"
 	"time"
 
 	jstime "github.com/anchore/k8s-inventory/internal/time"
 	"github.com/anchore/k8s-inventory/pkg/integration"
 
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
@@ -24,6 +27,7 @@ import (
 	"github.com/anchore/k8s-inventory/pkg/inventory"
 	"github.com/anchore/k8s-inventory/pkg/logger"
 	"github.com/anchore/k8s-inventory/pkg/reporter"
+	"github.com/anchore/k8s-inventory/pkg/watcher"
 )
 
 type ReportItem struct {
@@ -103,8 +107,6 @@ func HandleReport(report inventory.Report, reportInfo *healthreporter.InventoryR
 
 // PeriodicallyGetInventoryReport periodically retrieve image results and report/output them according to the configuration.
 // Note: Errors do not cause the function to exit, since this is periodically running
-//
-//nolint:gocognit
 func PeriodicallyGetInventoryReport(cfg *config.Application, ch integration.Channels, gatedReportInfo *healthreporter.GatedReportInfo) {
 	// Wait for registration with Enterprise to be disabled or completed
 	<-ch.InventoryReportingEnabled
@@ -114,71 +116,241 @@ func PeriodicallyGetInventoryReport(cfg *config.Application, ch integration.Chan
 	// Fire off a ticker that reports according to a configurable polling interval
 	ticker := time.NewTicker(time.Duration(cfg.PollingIntervalSeconds) * time.Second)
 
+	collector := &inventoryCollector{}
 	for {
-		reports, err := GetInventoryReports(cfg)
+		reports, err := collector.collect(cfg)
 		if err != nil {
-			log.Errorf("Failed to get Inventory Report: %w", err)
+			log.Errorf("Failed to get Inventory Report: %v", err)
 		} else {
-			for account, reportsForAccount := range reports {
-				reportInfo := healthreporter.InventoryReportInfo{
-					Account:             account,
-					BatchSize:           len(reportsForAccount),
-					LastSuccessfulIndex: -1,
-					Batches:             make([]healthreporter.BatchInfo, 0),
-					HasErrors:           false,
-				}
-				for count, report := range reportsForAccount {
-					log.Infof("Sending Inventory Report to Anchore Account %s, %d of %d", account, count+1, len(reportsForAccount))
-
-					reportInfo.ReportTimestamp = report.Timestamp
-					batchInfo := healthreporter.BatchInfo{
-						SendTimestamp: jstime.Datetime{Time: time.Now().UTC()},
-						BatchIndex:    count + 1,
-					}
-
-					err := HandleReport(report, &reportInfo, cfg, account)
-					if errors.Is(err, reporter.ErrAnchoreAccountDoesNotExist) {
-						// record this error for the health report even if the retry works
-						batchInfo.Error = fmt.Sprintf("%s (%s) | ", err.Error(), account)
-						reportInfo.HasErrors = true
-
-						// Retry with default account
-						retryAccount := cfg.AnchoreDetails.Account
-						if cfg.AccountRouteByNamespaceLabel.DefaultAccount != "" {
-							retryAccount = cfg.AccountRouteByNamespaceLabel.DefaultAccount
-						}
-						log.Warnf("Error sending to Anchore Account %s, sending to default account", account)
-						err = HandleReport(report, &reportInfo, cfg, retryAccount)
-					}
-					if err != nil {
-						log.Errorf("Failed to handle Inventory Report: %w", err)
-						// append the error to any error that happened during a retry, so we record both failures
-						batchInfo.Error += err.Error()
-						reportInfo.HasErrors = true
-					} else {
-						reportInfo.LastSuccessfulIndex = count + 1
-					}
-
-					select {
-					case isEnabled, isNotClosed := <-ch.HealthReportingEnabled:
-						if isNotClosed {
-							healthReportingEnabled = isEnabled
-						}
-						log.Infof("Health reporting enabled: %t", healthReportingEnabled)
-					default:
-					}
-					if healthReportingEnabled {
-						reportInfo.Batches = append(reportInfo.Batches, batchInfo)
-						healthreporter.SetReportInfoNoBlocking(account, count, reportInfo, gatedReportInfo)
-					}
-				}
-			}
+			processAndSendReports(cfg, reports, ch, gatedReportInfo, &healthReportingEnabled)
 		}
 
-		log.Infof("Waiting %d seconds for next poll...", cfg.PollingIntervalSeconds)
+		log.Infof("Waiting %d seconds for next report...", cfg.PollingIntervalSeconds)
 
 		// Wait at least as long as the ticker
 		log.Debugf("Start new gather: %s", <-ticker.C)
+	}
+}
+
+// How long to wait before retrying a failed attempt to start watching the
+// event stream. It grows on each consecutive failure so that a cluster the
+// agent is not allowed to watch settles into steady polling instead of
+// re-listing on every reporting interval.
+const (
+	eventStreamInitialRetryDelay = time.Minute
+	eventStreamMaxRetryDelay     = time.Hour
+)
+
+// eventStream is a started, synced set of informers and the client they were
+// built from
+type eventStream struct {
+	watcher   *watcher.Watcher
+	clientset kubernetes.Interface
+}
+
+// inventoryCollector gathers the inventory for one reporting interval, either
+// from the Kubernetes event stream or by polling the api-server, according to
+// the configured collection method.
+type inventoryCollector struct {
+	// guards the state shared with the goroutine that starts the informers
+	mu       sync.Mutex
+	stream   *eventStream
+	starting bool
+	retryIn  time.Duration
+
+	// only touched while building a report
+	serverVersion *version.Info
+}
+
+// collect builds the reports for a single reporting interval
+func (c *inventoryCollector) collect(cfg *config.Application) (BatchedReports, error) {
+	stream := c.eventStream(cfg)
+	if stream == nil {
+		return GetInventoryReports(cfg)
+	}
+
+	snapshot, err := stream.watcher.Snapshot()
+	if err != nil {
+		return BatchedReports{}, err
+	}
+
+	return GetInventoryReportsFromSnapshot(cfg, snapshot, c.refreshServerVersion(stream)), nil
+}
+
+// eventStream returns the synced event stream to collect this interval's
+// inventory from, or nil if it should be collected by polling instead.
+//
+// Starting the informers means waiting for their initial listing of the whole
+// cluster, so it happens in the background: reporting carries on by polling and
+// picks the event stream up on the first interval after it has synced. The
+// reporting cadence is therefore never held up by the cache sync deadline.
+func (c *inventoryCollector) eventStream(cfg *config.Application) *eventStream {
+	if cfg.InventoryCollection.Method != config.InventoryCollectionMethodInformer {
+		return nil
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.stream != nil {
+		return c.stream
+	}
+	if !c.starting {
+		c.starting = true
+		go c.startWatching(cfg)
+	}
+	return nil
+}
+
+// startWatching brings up the informers in the background and publishes them
+// once their caches have synced. On failure everything it started is stopped
+// again and another attempt is allowed after a growing delay.
+func (c *inventoryCollector) startWatching(cfg *config.Application) {
+	stream, err := newEventStream(cfg)
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if err == nil {
+		log.Info("Watching the Kubernetes event stream for inventory changes")
+		c.stream = stream
+		c.starting = false
+		c.retryIn = 0
+		return
+	}
+
+	c.retryIn = nextRetryDelay(c.retryIn)
+	log.Warnf("Unable to collect inventory from the Kubernetes event stream: %v", err)
+	log.Infof("Polling the api-server for inventory, the event stream will be retried in %s", c.retryIn)
+
+	// keep this attempt marked as in progress until the delay has passed, so
+	// that the reporting loop does not start another one in the meantime
+	time.AfterFunc(c.retryIn, func() {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		c.starting = false
+	})
+}
+
+func nextRetryDelay(current time.Duration) time.Duration {
+	if current <= 0 {
+		return eventStreamInitialRetryDelay
+	}
+	if next := current * 2; next < eventStreamMaxRetryDelay {
+		return next
+	}
+	return eventStreamMaxRetryDelay
+}
+
+// newEventStream builds the informers and blocks until their caches have synced
+func newEventStream(cfg *config.Application) (*eventStream, error) {
+	kubeconfig, err := client.GetKubeConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	clientset, err := client.GetClientSet(kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get k8s client set: %w", err)
+	}
+
+	informerCfg := cfg.InventoryCollection.Informer
+	w, err := watcher.New(clientset, watcher.Config{
+		RequestTimeout:   time.Duration(cfg.Kubernetes.RequestTimeoutSeconds) * time.Second,
+		CacheSyncTimeout: time.Duration(informerCfg.CacheSyncTimeoutSeconds) * time.Second,
+		Namespaces:       cfg.NamespaceSelectors.Include,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kubernetes watcher: %w", err)
+	}
+
+	// A fresh client and factory are built for each attempt on purpose - the
+	// informers of a failed attempt are stopped and cannot be restarted.
+	stopCh := make(chan struct{})
+	if err := w.Start(stopCh); err != nil {
+		close(stopCh)
+		return nil, fmt.Errorf("failed to watch the kubernetes event stream: %w", err)
+	}
+
+	return &eventStream{watcher: w, clientset: clientset}, nil
+}
+
+// refreshServerVersion re-reads the cluster server version that reports are
+// stamped with, so that a cluster upgrade is picked up without restarting the
+// agent. The last known version is kept if the lookup fails.
+func (c *inventoryCollector) refreshServerVersion(stream *eventStream) *version.Info {
+	serverVersion, err := stream.clientset.Discovery().ServerVersion()
+	if err != nil {
+		log.Warnf("Failed to get Cluster Server Version, reporting the last known version: %v", err)
+		return c.serverVersion
+	}
+
+	c.serverVersion = serverVersion
+	return c.serverVersion
+}
+
+// processAndSendReports sends every batched report to Anchore, recording the
+// outcome of each batch for the health report
+func processAndSendReports(
+	cfg *config.Application,
+	reports BatchedReports,
+	ch integration.Channels,
+	gatedReportInfo *healthreporter.GatedReportInfo,
+	healthReportingEnabled *bool,
+) {
+	for account, reportsForAccount := range reports {
+		reportInfo := healthreporter.InventoryReportInfo{
+			Account:             account,
+			BatchSize:           len(reportsForAccount),
+			LastSuccessfulIndex: -1,
+			Batches:             make([]healthreporter.BatchInfo, 0),
+			HasErrors:           false,
+		}
+		for count, report := range reportsForAccount {
+			log.Infof("Sending Inventory Report to Anchore Account %s, %d of %d", account, count+1, len(reportsForAccount))
+
+			reportInfo.ReportTimestamp = report.Timestamp
+			batchInfo := healthreporter.BatchInfo{
+				SendTimestamp: jstime.Datetime{Time: time.Now().UTC()},
+				BatchIndex:    count + 1,
+			}
+
+			err := HandleReport(report, &reportInfo, cfg, account)
+			if errors.Is(err, reporter.ErrAnchoreAccountDoesNotExist) {
+				// record this error for the health report even if the retry works
+				batchInfo.Error = fmt.Sprintf("%s (%s) | ", err.Error(), account)
+				reportInfo.HasErrors = true
+
+				// Retry with default account
+				retryAccount := cfg.AnchoreDetails.Account
+				if cfg.AccountRouteByNamespaceLabel.DefaultAccount != "" {
+					retryAccount = cfg.AccountRouteByNamespaceLabel.DefaultAccount
+				}
+				log.Warnf("Error sending to Anchore Account %s, sending to default account", account)
+				err = HandleReport(report, &reportInfo, cfg, retryAccount)
+			}
+			if err != nil {
+				log.Errorf("Failed to handle Inventory Report: %w", err)
+				// append the error to any error that happened during a retry, so we record both failures
+				batchInfo.Error += err.Error()
+				reportInfo.HasErrors = true
+			} else {
+				reportInfo.LastSuccessfulIndex = count + 1
+			}
+
+			select {
+			case isEnabled, isNotClosed := <-ch.HealthReportingEnabled:
+				if isNotClosed {
+					*healthReportingEnabled = isEnabled
+				}
+				log.Infof("Health reporting enabled: %t", *healthReportingEnabled)
+			default:
+			}
+			if *healthReportingEnabled {
+				reportInfo.Batches = append(reportInfo.Batches, batchInfo)
+				healthreporter.SetReportInfoNoBlocking(account, count, reportInfo, gatedReportInfo)
+			}
+		}
 	}
 }
 
@@ -311,6 +483,140 @@ func GetInventoryReportForNamespaces(
 		ServerVersionMetadata: serverVersion,
 		ClusterName:           cfg.KubeConfig.Cluster,
 	}, nil
+}
+
+// snapshotInventory is the account agnostic view of a cluster snapshot, indexed
+// so that it can be sliced up per Anchore account
+type snapshotInventory struct {
+	namespaces            []inventory.Namespace
+	nodes                 []inventory.Node
+	podsByNamespace       map[string][]inventory.Pod
+	containersByNamespace map[string][]inventory.Container
+}
+
+// processSnapshot converts a snapshot of the cluster into inventory types,
+// applying the configured namespace selectors and metadata collection rules
+func processSnapshot(cfg *config.Application, snapshot watcher.Snapshot) snapshotInventory {
+	nodeMap := make(map[string]inventory.Node, len(snapshot.Nodes))
+	for _, node := range snapshot.Nodes {
+		nodeMap[node.Name] = inventory.NodeFromV1(
+			node,
+			cfg.MetadataCollection.Nodes.Annotations,
+			cfg.MetadataCollection.Nodes.Labels,
+			cfg.MetadataCollection.Nodes.Disable,
+		)
+	}
+
+	podsByNamespaceName := make(map[string][]v1.Pod)
+	for _, pod := range snapshot.Pods {
+		podsByNamespaceName[pod.Namespace] = append(podsByNamespaceName[pod.Namespace], *pod)
+	}
+
+	inv := snapshotInventory{
+		nodes:                 make([]inventory.Node, 0, len(nodeMap)),
+		podsByNamespace:       make(map[string][]inventory.Pod),
+		containersByNamespace: make(map[string][]inventory.Container),
+	}
+	for _, node := range nodeMap {
+		inv.nodes = append(inv.nodes, node)
+	}
+
+	// Pods reference their namespace by name, so a namespace that was deleted
+	// and recreated within one interval cannot have its pods attributed to one
+	// object or the other. Each name is processed once, taking the first
+	// occurrence, which the watcher orders as the one still in the cluster.
+	seen := make(map[string]struct{}, len(snapshot.Namespaces))
+	filter := inventory.NewNamespaceFilter(cfg.NamespaceSelectors.Exclude, cfg.NamespaceSelectors.Include)
+	for _, n := range snapshot.Namespaces {
+		if !filter.Keep(n.Name) {
+			continue
+		}
+		if _, duplicate := seen[n.Name]; duplicate {
+			log.Debugf("Namespace \"%s\" appears more than once in the snapshot, only reporting the first", n.Name)
+			continue
+		}
+		seen[n.Name] = struct{}{}
+
+		v1pods := podsByNamespaceName[n.Name]
+		if cfg.NamespaceSelectors.IgnoreEmpty && len(v1pods) == 0 {
+			log.Debugf("Ignoring namespace \"%s\" as it has no pods", n.Name)
+			continue
+		}
+
+		ns := inventory.NamespaceFromV1(
+			n,
+			cfg.MetadataCollection.Namespace.Annotations,
+			cfg.MetadataCollection.Namespace.Labels,
+			cfg.MetadataCollection.Namespace.Disable,
+		)
+		inv.namespaces = append(inv.namespaces, ns)
+		inv.podsByNamespace[ns.UID] = inventory.ProcessPods(
+			v1pods, ns.UID, nodeMap,
+			cfg.MetadataCollection.Pods.Annotations,
+			cfg.MetadataCollection.Pods.Labels,
+			cfg.MetadataCollection.Pods.Disable,
+		)
+		inv.containersByNamespace[ns.UID] = inventory.GetContainersFromPods(
+			v1pods,
+			cfg.IgnoreNotRunning,
+			cfg.MissingRegistryOverride,
+			cfg.MissingTagPolicy.Policy,
+			cfg.MissingTagPolicy.Tag,
+		)
+	}
+
+	return inv
+}
+
+// reportForNamespaces builds a report containing the given subset of the
+// snapshot's namespaces. As with the polling collection method every node is
+// included in each report regardless of which namespaces it is carrying.
+func (inv snapshotInventory) reportForNamespaces(
+	cfg *config.Application,
+	namespaces []inventory.Namespace,
+	serverVersion *version.Info,
+	timestamp string,
+) inventory.Report {
+	pods := make([]inventory.Pod, 0)
+	containers := make([]inventory.Container, 0)
+	for _, ns := range namespaces {
+		pods = append(pods, inv.podsByNamespace[ns.UID]...)
+		containers = append(containers, inv.containersByNamespace[ns.UID]...)
+	}
+
+	log.Infof("Got Inventory Report with %d containers running across %d namespaces", len(containers), len(namespaces))
+	return inventory.Report{
+		Timestamp:             timestamp,
+		Containers:            containers,
+		Pods:                  pods,
+		Namespaces:            namespaces,
+		Nodes:                 inv.nodes,
+		ServerVersionMetadata: serverVersion,
+		ClusterName:           cfg.KubeConfig.Cluster,
+	}
+}
+
+// GetInventoryReportsFromSnapshot builds the account routed, batched inventory
+// reports for a snapshot of the cluster taken from the Kubernetes event stream
+func GetInventoryReportsFromSnapshot(cfg *config.Application, snapshot watcher.Snapshot, serverVersion *version.Info) BatchedReports {
+	log.Info("Starting image inventory collection from the Kubernetes event stream")
+
+	inv := processSnapshot(cfg, snapshot)
+	timestamp := time.Now().UTC().Format(time.RFC3339)
+
+	reports := AccountRoutedReports{}
+	if len(cfg.AccountRoutes) == 0 && cfg.AccountRouteByNamespaceLabel.LabelKey == "" {
+		reports[cfg.AnchoreDetails.Account] = inv.reportForNamespaces(cfg, inv.namespaces, serverVersion, timestamp)
+	} else {
+		accountRoutesForAllNamespaces := GetAccountRoutedNamespaces(
+			cfg.AnchoreDetails.Account, inv.namespaces, cfg.AccountRoutes, cfg.AccountRouteByNamespaceLabel)
+
+		for account, namespaces := range accountRoutesForAllNamespaces {
+			reports[account] = inv.reportForNamespaces(cfg, namespaces, serverVersion, timestamp)
+		}
+	}
+
+	return getBatchedInventoryReports(reports, cfg.InventoryReportLimits)
 }
 
 func GetAllNamespaces(cfg *config.Application) ([]inventory.Namespace, error) {

--- a/pkg/lib_snapshot_test.go
+++ b/pkg/lib_snapshot_test.go
@@ -1,0 +1,389 @@
+package pkg
+
+import (
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/version"
+
+	"github.com/anchore/k8s-inventory/internal/config"
+	"github.com/anchore/k8s-inventory/pkg/inventory"
+	"github.com/anchore/k8s-inventory/pkg/watcher"
+)
+
+var testServerVersion = &version.Info{Major: "1", Minor: "30"}
+
+func snapshotNamespace(name string, uid types.UID, labels map[string]string) *v1.Namespace {
+	return &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			UID:         uid,
+			Labels:      labels,
+			Annotations: map[string]string{"anchore.io/annotation": "annotation-value"},
+		},
+	}
+}
+
+func snapshotPod(name, namespace string, uid types.UID, phase v1.PodPhase) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			UID:         uid,
+			Labels:      map[string]string{"anchore.io/label": "label-value"},
+			Annotations: map[string]string{"anchore.io/annotation": "annotation-value"},
+		},
+		Spec: v1.PodSpec{
+			NodeName:   "test-node",
+			Containers: []v1.Container{{Name: name, Image: "anchore/test:latest"}},
+		},
+		Status: v1.PodStatus{
+			Phase: phase,
+			ContainerStatuses: []v1.ContainerStatus{
+				{
+					Name:        name,
+					ContainerID: "containerd://" + string(uid),
+					Image:       "anchore/test:latest",
+					ImageID:     "anchore/test@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+				},
+			},
+		},
+	}
+}
+
+func testSnapshot() watcher.Snapshot {
+	return watcher.Snapshot{
+		Namespaces: []*v1.Namespace{
+			snapshotNamespace("ns1", "ns1_UID", map[string]string{"anchore.io/account": "account1"}),
+			snapshotNamespace("ns2", "ns2_UID", map[string]string{"anchore.io/account": "account2"}),
+			snapshotNamespace("empty-ns", "empty_ns_UID", nil),
+		},
+		Pods: []*v1.Pod{
+			snapshotPod("pod1", "ns1", "pod1_UID", v1.PodRunning),
+			snapshotPod("pod2", "ns2", "pod2_UID", v1.PodRunning),
+		},
+		Nodes: []*v1.Node{
+			{ObjectMeta: metav1.ObjectMeta{Name: "test-node", UID: "node_UID"}},
+		},
+	}
+}
+
+func baseConfig() *config.Application {
+	return &config.Application{
+		AnchoreDetails:   config.AnchoreInfo{Account: "admin"},
+		KubeConfig:       config.KubeConf{Cluster: "test-cluster"},
+		IgnoreNotRunning: true,
+		MissingTagPolicy: config.MissingTagConf{Policy: "digest"},
+	}
+}
+
+func namespaceNames(report inventory.Report) []string {
+	names := make([]string, 0, len(report.Namespaces))
+	for _, ns := range report.Namespaces {
+		names = append(names, ns.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func podNames(report inventory.Report) []string {
+	names := make([]string, 0, len(report.Pods))
+	for _, pod := range report.Pods {
+		names = append(names, pod.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func TestGetInventoryReportsFromSnapshot(t *testing.T) {
+	cfg := baseConfig()
+
+	batched := GetInventoryReportsFromSnapshot(cfg, testSnapshot(), testServerVersion)
+
+	require.Len(t, batched, 1)
+	require.Len(t, batched["admin"], 1)
+	report := batched["admin"][0]
+
+	assert.Equal(t, "test-cluster", report.ClusterName)
+	assert.Equal(t, testServerVersion, report.ServerVersionMetadata)
+	assert.NotEmpty(t, report.Timestamp)
+	assert.Equal(t, []string{"empty-ns", "ns1", "ns2"}, namespaceNames(report))
+	assert.Equal(t, []string{"pod1", "pod2"}, podNames(report))
+	require.Len(t, report.Nodes, 1)
+	assert.Equal(t, "test-node", report.Nodes[0].Name)
+
+	require.Len(t, report.Containers, 2)
+	for _, container := range report.Containers {
+		assert.Equal(t, "anchore/test:latest", container.ImageTag)
+	}
+
+	// pods are linked back to their namespace and node
+	for _, pod := range report.Pods {
+		assert.Equal(t, "node_UID", pod.NodeUID)
+		assert.NotEmpty(t, pod.NamespaceUID)
+	}
+}
+
+func TestGetInventoryReportsFromSnapshotIncludesDeletedPods(t *testing.T) {
+	cfg := baseConfig()
+
+	snapshot := testSnapshot()
+	// a pod the watcher buffered because it was deleted between two reports -
+	// its namespace was deleted along with it, so it is buffered too
+	snapshot.Namespaces = append(snapshot.Namespaces, snapshotNamespace("flash-ns", "flash_ns_UID", nil))
+	snapshot.Pods = append(snapshot.Pods, snapshotPod("transient-pod", "flash-ns", "transient_UID", v1.PodRunning))
+
+	batched := GetInventoryReportsFromSnapshot(cfg, snapshot, testServerVersion)
+	report := batched["admin"][0]
+
+	assert.Contains(t, namespaceNames(report), "flash-ns")
+	assert.Contains(t, podNames(report), "transient-pod")
+
+	containerIDs := make([]string, 0, len(report.Containers))
+	for _, container := range report.Containers {
+		containerIDs = append(containerIDs, container.ID)
+	}
+	assert.Contains(t, containerIDs, "containerd://transient_UID")
+}
+
+func TestGetInventoryReportsFromSnapshotIgnoreNotRunning(t *testing.T) {
+	snapshot := testSnapshot()
+	snapshot.Pods = append(snapshot.Pods, snapshotPod("pending-pod", "ns1", "pending_UID", v1.PodPending))
+
+	tests := []struct {
+		name             string
+		ignoreNotRunning bool
+		wantContainers   int
+	}{
+		{name: "not running pods are dropped", ignoreNotRunning: true, wantContainers: 2},
+		{name: "not running pods are reported", ignoreNotRunning: false, wantContainers: 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := baseConfig()
+			cfg.IgnoreNotRunning = tt.ignoreNotRunning
+
+			report := GetInventoryReportsFromSnapshot(cfg, snapshot, testServerVersion)["admin"][0]
+
+			assert.Len(t, report.Containers, tt.wantContainers)
+			// the pod itself is always reported, only its containers are filtered
+			assert.Contains(t, podNames(report), "pending-pod")
+		})
+	}
+}
+
+func TestGetInventoryReportsFromSnapshotNamespaceSelectors(t *testing.T) {
+	tests := []struct {
+		name      string
+		selectors config.NamespaceSelector
+		want      []string
+	}{
+		{
+			name: "namespaces can be excluded",
+			selectors: config.NamespaceSelector{
+				Exclude: []string{"^empty-.*"},
+			},
+			want: []string{"ns1", "ns2"},
+		},
+		{
+			name: "includes act as an allow-list",
+			selectors: config.NamespaceSelector{
+				Include: []string{"ns1"},
+			},
+			want: []string{"ns1"},
+		},
+		{
+			name: "empty namespaces can be ignored",
+			selectors: config.NamespaceSelector{
+				IgnoreEmpty: true,
+			},
+			want: []string{"ns1", "ns2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := baseConfig()
+			cfg.NamespaceSelectors = tt.selectors
+
+			report := GetInventoryReportsFromSnapshot(cfg, testSnapshot(), testServerVersion)["admin"][0]
+
+			assert.Equal(t, tt.want, namespaceNames(report))
+		})
+	}
+}
+
+func TestGetInventoryReportsFromSnapshotAccountRouting(t *testing.T) {
+	tests := []struct {
+		name         string
+		configure    func(*config.Application)
+		wantAccounts map[string][]string
+	}{
+		{
+			name: "routing by namespace label",
+			configure: func(cfg *config.Application) {
+				cfg.AccountRouteByNamespaceLabel = config.AccountRouteByNamespaceLabel{
+					LabelKey: "anchore.io/account",
+				}
+			},
+			wantAccounts: map[string][]string{
+				"account1": {"ns1"},
+				"account2": {"ns2"},
+				"admin":    {"empty-ns"},
+			},
+		},
+		{
+			name: "routing by explicit account routes",
+			configure: func(cfg *config.Application) {
+				cfg.AccountRoutes = config.AccountRoutes{
+					"routed-account": config.AccountRouteDetails{Namespaces: []string{"^ns.*"}},
+				}
+			},
+			wantAccounts: map[string][]string{
+				"routed-account": {"ns1", "ns2"},
+				"admin":          {"empty-ns"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := baseConfig()
+			tt.configure(cfg)
+
+			batched := GetInventoryReportsFromSnapshot(cfg, testSnapshot(), testServerVersion)
+
+			require.Len(t, batched, len(tt.wantAccounts))
+			for account, namespaces := range tt.wantAccounts {
+				require.Len(t, batched[account], 1, "expected a single report for account %s", account)
+				assert.Equal(t, namespaces, namespaceNames(batched[account][0]))
+				// every report carries the full node list, as with polling
+				assert.Len(t, batched[account][0].Nodes, 1)
+			}
+		})
+	}
+}
+
+func TestGetInventoryReportsFromSnapshotBatches(t *testing.T) {
+	cfg := baseConfig()
+	cfg.InventoryReportLimits = config.InventoryReportLimits{Namespaces: 1}
+
+	batched := GetInventoryReportsFromSnapshot(cfg, testSnapshot(), testServerVersion)
+
+	require.Len(t, batched["admin"], 3)
+	for _, report := range batched["admin"] {
+		assert.Len(t, report.Namespaces, 1)
+	}
+}
+
+func TestGetInventoryReportsFromSnapshotMetadataCollection(t *testing.T) {
+	cfg := baseConfig()
+	cfg.MetadataCollection = config.MetadataCollection{
+		Namespace: config.ResourceMetadata{Disable: true},
+		Pods:      config.ResourceMetadata{Disable: true},
+		Nodes:     config.ResourceMetadata{Disable: true},
+	}
+
+	report := GetInventoryReportsFromSnapshot(cfg, testSnapshot(), testServerVersion)["admin"][0]
+
+	for _, ns := range report.Namespaces {
+		assert.Empty(t, ns.Labels)
+		assert.Empty(t, ns.Annotations)
+	}
+	for _, pod := range report.Pods {
+		assert.Empty(t, pod.Labels)
+		assert.Empty(t, pod.Annotations)
+	}
+	for _, node := range report.Nodes {
+		assert.Empty(t, node.Labels)
+		assert.Empty(t, node.Annotations)
+	}
+}
+
+func TestGetInventoryReportsFromSnapshotEmptyCluster(t *testing.T) {
+	cfg := baseConfig()
+
+	batched := GetInventoryReportsFromSnapshot(cfg, watcher.Snapshot{}, testServerVersion)
+
+	require.Len(t, batched["admin"], 1)
+	report := batched["admin"][0]
+	assert.Empty(t, report.Namespaces)
+	assert.Empty(t, report.Pods)
+	assert.Empty(t, report.Containers)
+	assert.Empty(t, report.Nodes)
+}
+
+func TestGetInventoryReportsFromSnapshotCollapsesDuplicateNamespaceNames(t *testing.T) {
+	cfg := baseConfig()
+
+	// a namespace deleted and recreated within one interval appears twice in a
+	// snapshot, once from the deletion buffer and once from the informer cache.
+	// Pods reference their namespace by name, so reporting both would emit
+	// every pod and container in it twice.
+	snapshot := watcher.Snapshot{
+		Namespaces: []*v1.Namespace{
+			snapshotNamespace("ns1", "ns1_UID", nil),
+			snapshotNamespace("ns1", "ns1_UID_v2", nil),
+		},
+		Pods: []*v1.Pod{
+			snapshotPod("pod1", "ns1", "pod1_UID", v1.PodRunning),
+			snapshotPod("pod2", "ns1", "pod2_UID", v1.PodRunning),
+		},
+	}
+
+	report := GetInventoryReportsFromSnapshot(cfg, snapshot, testServerVersion)["admin"][0]
+
+	require.Len(t, report.Namespaces, 1)
+	assert.Equal(t, "ns1_UID", report.Namespaces[0].UID, "the first namespace, which the watcher orders as the live one, should win")
+	assert.Equal(t, []string{"pod1", "pod2"}, podNames(report))
+	assert.Len(t, report.Containers, 2)
+
+	// every pod is attributed to the single reported namespace
+	for _, pod := range report.Pods {
+		assert.Equal(t, "ns1_UID", pod.NamespaceUID)
+	}
+}
+
+func TestGetInventoryReportsFromSnapshotRefreshesNothingWithoutAServerVersion(t *testing.T) {
+	// the collector keeps the last known version when a lookup fails, which can
+	// be nil if the very first lookup failed
+	report := GetInventoryReportsFromSnapshot(baseConfig(), testSnapshot(), nil)["admin"][0]
+
+	assert.Nil(t, report.ServerVersionMetadata)
+	assert.NotEmpty(t, report.Namespaces)
+}
+
+func TestEventStreamIsNotUsedWhenPollingIsConfigured(t *testing.T) {
+	cfg := baseConfig()
+	cfg.InventoryCollection.Method = config.InventoryCollectionMethodPoll
+
+	collector := &inventoryCollector{}
+
+	// the revert switch keeps the agent on the legacy collection path, without
+	// so much as trying to start the informers
+	assert.Nil(t, collector.eventStream(cfg))
+	assert.Nil(t, collector.stream)
+	assert.False(t, collector.starting)
+}
+
+func TestNextRetryDelay(t *testing.T) {
+	tests := []struct {
+		name    string
+		current time.Duration
+		want    time.Duration
+	}{
+		{name: "the first failure waits the initial delay", current: 0, want: eventStreamInitialRetryDelay},
+		{name: "each consecutive failure waits longer", current: time.Minute, want: 2 * time.Minute},
+		{name: "the delay is capped", current: 45 * time.Minute, want: eventStreamMaxRetryDelay},
+		{name: "the cap is not exceeded once reached", current: eventStreamMaxRetryDelay, want: eventStreamMaxRetryDelay},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, nextRetryDelay(tt.current))
+		})
+	}
+}

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -1,0 +1,374 @@
+/*
+Package watcher maintains a live view of the cluster by watching the Kubernetes
+event stream with informers rather than listing every resource on each polling
+interval.
+
+As well as removing the periodic LIST load from the api-server, watching the
+event stream means that resources which are created and destroyed *between* two
+inventory reports are still observed. Those resources are buffered until the
+next report is generated so that short lived pods (and the containers within
+them) are no longer missed.
+*/
+package watcher
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	listersv1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/anchore/k8s-inventory/internal/log"
+)
+
+// The informers are created without a resync period. A client-go resync does
+// not contact the api-server or reconcile the cache against it - it only
+// redelivers the objects already cached to the event handlers. The handlers
+// here just re-store a pointer they already hold, so a resync would cost a
+// redelivery of every cached pod and buy nothing.
+const noResync = time.Duration(0)
+
+// Config holds the tuning options for a Watcher
+type Config struct {
+	// RequestTimeout bounds the one-off requests the watcher makes itself,
+	// outside of the informers
+	RequestTimeout time.Duration
+	// CacheSyncTimeout bounds how long Start waits for the informer caches to
+	// fill. Zero waits for as long as it takes.
+	CacheSyncTimeout time.Duration
+	// Namespaces is the configured namespace allow-list. When it names exactly
+	// one namespace the pod informer is scoped to it, so that the agent does
+	// not cache pods it is going to discard.
+	Namespaces []string
+}
+
+// Snapshot is a point in time view of the cluster. It contains everything the
+// informer caches currently hold plus anything that was deleted since the
+// previous snapshot was taken.
+//
+// The objects it references are owned by the informer caches and must not be
+// modified.
+type Snapshot struct {
+	Namespaces []*v1.Namespace
+	Pods       []*v1.Pod
+	Nodes      []*v1.Node
+}
+
+// Watcher owns the informers for the resources that make up an inventory
+// report and buffers deletions between snapshots.
+type Watcher struct {
+	factory          informers.SharedInformerFactory
+	podLister        listersv1.PodLister
+	nsLister         listersv1.NamespaceLister
+	nodeLister       listersv1.NodeLister
+	nodesEnabled     bool
+	cacheSyncTimeout time.Duration
+
+	mu sync.Mutex
+	// lastRunning holds the most recent Running snapshot of each pod so that a
+	// pod which has already completed by the time it is deleted is still
+	// reported as it was while running
+	lastRunning map[types.UID]*v1.Pod
+	// deletedPods is keyed by UID, as a pod that is deleted and recreated under
+	// the same name is genuinely two different pods and both should be reported
+	deletedPods map[string]*v1.Pod
+	// deletedNamespaces and deletedNodes are keyed by name, because pods
+	// reference their namespace and node by name. Two objects sharing a name
+	// could not be told apart when attributing pods to them, so the most
+	// recently deleted one wins and anything still in the cache wins over that.
+	deletedNamespaces map[string]*v1.Namespace
+	deletedNodes      map[string]*v1.Node
+}
+
+// New builds a Watcher for the given clientset
+func New(clientset kubernetes.Interface, cfg Config) (*Watcher, error) {
+	w := &Watcher{
+		factory:           informers.NewSharedInformerFactoryWithOptions(clientset, noResync, factoryOptions(cfg)...),
+		cacheSyncTimeout:  cfg.CacheSyncTimeout,
+		lastRunning:       make(map[types.UID]*v1.Pod),
+		deletedPods:       make(map[string]*v1.Pod),
+		deletedNamespaces: make(map[string]*v1.Namespace),
+		deletedNodes:      make(map[string]*v1.Node),
+	}
+
+	podInformer := w.factory.Core().V1().Pods()
+	// managed fields are never reported and are a significant part of the
+	// memory footprint of a cluster wide pod cache
+	if err := podInformer.Informer().SetTransform(stripManagedFields); err != nil {
+		return nil, fmt.Errorf("failed to set pod informer transform: %w", err)
+	}
+	if _, err := podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { w.onPodUpsert(obj) },
+		UpdateFunc: func(_, obj interface{}) { w.onPodUpsert(obj) },
+		DeleteFunc: w.onPodDelete,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to add pod event handler: %w", err)
+	}
+	w.podLister = podInformer.Lister()
+
+	nsInformer := w.factory.Core().V1().Namespaces()
+	if _, err := nsInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		DeleteFunc: w.onNamespaceDelete,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to add namespace event handler: %w", err)
+	}
+	w.nsLister = nsInformer.Lister()
+
+	// Nodes are optional - the agent tolerates not being allowed to read them
+	if canListNodes(clientset, cfg.RequestTimeout) {
+		nodeInformer := w.factory.Core().V1().Nodes()
+		if _, err := nodeInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+			DeleteFunc: w.onNodeDelete,
+		}); err != nil {
+			return nil, fmt.Errorf("failed to add node event handler: %w", err)
+		}
+		w.nodeLister = nodeInformer.Lister()
+		w.nodesEnabled = true
+	}
+
+	return w, nil
+}
+
+// factoryOptions scopes the pod informer to a single namespace when that is all
+// the configuration asks for. Namespace and node informers are cluster scoped
+// and are unaffected by this.
+func factoryOptions(cfg Config) []informers.SharedInformerOption {
+	if len(cfg.Namespaces) != 1 {
+		return nil
+	}
+	log.Infof("Watching pods in namespace %s only", cfg.Namespaces[0])
+	return []informers.SharedInformerOption{informers.WithNamespace(cfg.Namespaces[0])}
+}
+
+// Start begins watching and blocks until every informer cache has synced.
+//
+// Syncing is bounded by the configured cache sync timeout because informers
+// retry a rejected LIST indefinitely, which would otherwise leave the agent
+// waiting forever on a cluster it is not permitted to watch rather than
+// reporting an error.
+func (w *Watcher) Start(stopCh <-chan struct{}) error {
+	w.factory.Start(stopCh)
+
+	syncCh := stopCh
+	if w.cacheSyncTimeout > 0 {
+		deadlineCh := make(chan struct{})
+		synced := make(chan struct{})
+		defer close(synced)
+		go func() {
+			timer := time.NewTimer(w.cacheSyncTimeout)
+			defer timer.Stop()
+			select {
+			case <-stopCh:
+			case <-timer.C:
+			case <-synced:
+			}
+			close(deadlineCh)
+		}()
+		syncCh = deadlineCh
+	}
+
+	for informerType, hasSynced := range w.factory.WaitForCacheSync(syncCh) {
+		if !hasSynced {
+			return fmt.Errorf("failed to sync informer cache for %s within %s", informerType, w.cacheSyncTimeout)
+		}
+	}
+	return nil
+}
+
+// Snapshot returns the current contents of the informer caches merged with
+// everything deleted since the last call. The deletion buffers are reset so
+// that each deleted resource is reported exactly once.
+func (w *Watcher) Snapshot() (Snapshot, error) {
+	// held across the lister reads so that the deletion buffers and the caches
+	// they are merged with cannot move relative to each other
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	pods, err := w.podLister.List(labels.Everything())
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("failed to list pods from informer cache: %w", err)
+	}
+	namespaces, err := w.nsLister.List(labels.Everything())
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("failed to list namespaces from informer cache: %w", err)
+	}
+	var nodes []*v1.Node
+	if w.nodesEnabled {
+		nodes, err = w.nodeLister.List(labels.Everything())
+		if err != nil {
+			return Snapshot{}, fmt.Errorf("failed to list nodes from informer cache: %w", err)
+		}
+	}
+
+	snapshot := Snapshot{
+		Pods:       mergeDeleted(pods, w.deletedPods, uidKey),
+		Namespaces: mergeDeleted(namespaces, w.deletedNamespaces, nameKey),
+		Nodes:      mergeDeleted(nodes, w.deletedNodes, nameKey),
+	}
+
+	log.Debugf(
+		"Snapshot taken from informer caches: %d namespaces, %d pods, %d nodes (including %d deleted pods)",
+		len(snapshot.Namespaces), len(snapshot.Pods), len(snapshot.Nodes), len(w.deletedPods),
+	)
+
+	w.deletedPods = make(map[string]*v1.Pod)
+	w.deletedNamespaces = make(map[string]*v1.Namespace)
+	w.deletedNodes = make(map[string]*v1.Node)
+
+	// lastRunning is deliberately not pruned against the pods just listed. The
+	// informer removes an object from its cache on one goroutine and delivers
+	// the delete event on another, so a pod can be absent from the listing while
+	// its delete event is still queued. Evicting it here would leave nothing for
+	// onPodDelete to buffer but the pod's final, possibly completed, state,
+	// which ignore-not-running would then discard - losing exactly the transient
+	// container this exists to capture. Every removal from the cache delivers a
+	// delete event, including the tombstones a relist synthesises after a watch
+	// gap, and onPodDelete always drops the entry, so the map stays bounded.
+
+	return snapshot, nil
+}
+
+// NodesEnabled reports whether the agent is able to watch nodes
+func (w *Watcher) NodesEnabled() bool {
+	return w.nodesEnabled
+}
+
+func (w *Watcher) onPodUpsert(obj interface{}) {
+	pod, ok := obj.(*v1.Pod)
+	if !ok {
+		return
+	}
+	// Only running pods are remembered. A pod that comes and goes between two
+	// reports is reported as it was while running, which keeps the behaviour of
+	// the ignore-not-running option intact.
+	if pod.Status.Phase != v1.PodRunning {
+		return
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.lastRunning[pod.UID] = pod
+}
+
+func (w *Watcher) onPodDelete(obj interface{}) {
+	pod, ok := fromTombstone[*v1.Pod](obj)
+	if !ok {
+		return
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if lastRunning, ok := w.lastRunning[pod.UID]; ok {
+		// prefer the running snapshot, it is the one that carries the container
+		// statuses (and therefore the image digests) we want to report
+		w.deletedPods[string(pod.UID)] = lastRunning
+		delete(w.lastRunning, pod.UID)
+	} else {
+		w.deletedPods[string(pod.UID)] = pod
+	}
+	log.Debugf("Buffered deleted pod %s/%s for the next inventory report", pod.Namespace, pod.Name)
+}
+
+func (w *Watcher) onNamespaceDelete(obj interface{}) {
+	namespace, ok := fromTombstone[*v1.Namespace](obj)
+	if !ok {
+		return
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	// buffered so that pods deleted along with their namespace still have a
+	// parent namespace in the report
+	w.deletedNamespaces[namespace.Name] = namespace
+}
+
+func (w *Watcher) onNodeDelete(obj interface{}) {
+	node, ok := fromTombstone[*v1.Node](obj)
+	if !ok {
+		return
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.deletedNodes[node.Name] = node
+}
+
+func uidKey(obj metav1.Object) string  { return string(obj.GetUID()) }
+func nameKey(obj metav1.Object) string { return obj.GetName() }
+
+// mergeDeleted combines the objects currently held in an informer cache with
+// the buffered deleted objects, ignoring any deleted object whose key is back
+// in the cache
+func mergeDeleted[PT metav1.Object](current []PT, deleted map[string]PT, keyOf func(metav1.Object) string) []PT {
+	merged := make([]PT, 0, len(current)+len(deleted))
+	present := make(map[string]struct{}, len(current))
+	for _, obj := range current {
+		present[keyOf(obj)] = struct{}{}
+		merged = append(merged, obj)
+	}
+	for key, obj := range deleted {
+		if _, ok := present[key]; ok {
+			continue
+		}
+		merged = append(merged, obj)
+	}
+	return merged
+}
+
+// fromTombstone extracts the deleted object from a delete event, unwrapping the
+// tombstone the informer delivers when it missed the delete itself
+func fromTombstone[T any](obj interface{}) (T, bool) {
+	if typed, ok := obj.(T); ok {
+		return typed, true
+	}
+	if tombstone, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+		if typed, ok := tombstone.Obj.(T); ok {
+			return typed, true
+		}
+	}
+	log.Debugf("Ignoring delete event for unexpected object type %T", obj)
+	var zero T
+	return zero, false
+}
+
+// stripManagedFields drops the managedFields metadata before an object is put
+// into an informer cache. It is never reported and is a large part of the
+// memory footprint of a cluster wide cache.
+func stripManagedFields(obj interface{}) (interface{}, error) {
+	if accessor, ok := obj.(metav1.ObjectMetaAccessor); ok {
+		accessor.GetObjectMeta().SetManagedFields(nil)
+	}
+	return obj, nil
+}
+
+// canListNodes probes whether the agent is permitted to read nodes. Listing
+// nodes is optional - the poll based collection tolerates being forbidden from
+// doing so and the informer based collection does the same.
+//
+// Only being forbidden disables the node informer. Any other failure is treated
+// as transient and left to the informer to retry.
+func canListNodes(clientset kubernetes.Interface, requestTimeout time.Duration) bool {
+	ctx := context.Background()
+	if requestTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, requestTimeout)
+		defer cancel()
+	}
+
+	limit := int64(1)
+	_, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{Limit: limit})
+	if err != nil && k8sErrors.IsForbidden(err) {
+		log.Warnf("not permitted to watch nodes, node inventory will not be collected: %v", err)
+		return false
+	}
+	return true
+}

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -1,0 +1,464 @@
+package watcher
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+)
+
+const eventTimeout = 5 * time.Second
+
+func newPod(name string, uid types.UID, phase v1.PodPhase) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			UID:       uid,
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				{Manager: "kubelet"},
+			},
+		},
+		Spec: v1.PodSpec{
+			NodeName:   "test-node",
+			Containers: []v1.Container{{Name: name, Image: "anchore/test:latest"}},
+		},
+		Status: v1.PodStatus{Phase: phase},
+	}
+}
+
+func newNamespace(name string) *v1.Namespace {
+	return &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(name + "-uid")}}
+}
+
+func newNode(name string) *v1.Node {
+	return &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(name + "-uid")}}
+}
+
+// startWatcher builds a watcher against the given clientset and runs it until
+// the test finishes
+func startWatcher(t *testing.T, clientset kubernetes.Interface) *Watcher {
+	t.Helper()
+
+	w, err := New(clientset, Config{CacheSyncTimeout: eventTimeout})
+	require.NoError(t, err)
+
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	require.NoError(t, w.Start(stopCh))
+
+	return w
+}
+
+// waitFor polls the watcher state until the condition holds. Informers deliver
+// events to handlers asynchronously, so tests have to wait for the watcher to
+// have observed an event rather than assuming it already has.
+func waitFor(t *testing.T, condition func() bool) {
+	t.Helper()
+	require.Eventually(t, condition, eventTimeout, 5*time.Millisecond)
+}
+
+// waitForCachedPod waits until the pod informer cache holds the named pod in
+// the given phase
+func waitForCachedPod(t *testing.T, w *Watcher, name string, phase v1.PodPhase) {
+	t.Helper()
+	waitFor(t, func() bool {
+		pod, err := w.podLister.Pods("default").Get(name)
+		return err == nil && pod.Status.Phase == phase
+	})
+}
+
+// underLock runs a read of the watcher's internal state with the mutex held,
+// as the informer handler goroutines are still running during the tests
+func underLock[T any](w *Watcher, read func() T) T {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return read()
+}
+
+// waitForBuffered waits until the given check of the watcher's buffers holds
+func waitForBuffered(t *testing.T, w *Watcher, check func() bool) {
+	t.Helper()
+	waitFor(t, func() bool {
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		return check()
+	})
+}
+
+func namespaceNames(snapshot Snapshot) []string {
+	names := make([]string, 0, len(snapshot.Namespaces))
+	for _, ns := range snapshot.Namespaces {
+		names = append(names, ns.Name)
+	}
+	return names
+}
+
+func podNames(snapshot Snapshot) []string {
+	names := make([]string, 0, len(snapshot.Pods))
+	for _, pod := range snapshot.Pods {
+		names = append(names, pod.Name)
+	}
+	return names
+}
+
+func TestSnapshotIncludesCurrentClusterState(t *testing.T) {
+	clientset := fake.NewClientset(
+		newNamespace("default"),
+		newNode("test-node"),
+		newPod("running-pod", "pod-uid", v1.PodRunning),
+	)
+	w := startWatcher(t, clientset)
+
+	snapshot, err := w.Snapshot()
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"running-pod"}, podNames(snapshot))
+	require.Len(t, snapshot.Namespaces, 1)
+	assert.Equal(t, "default", snapshot.Namespaces[0].Name)
+	require.Len(t, snapshot.Nodes, 1)
+	assert.Equal(t, "test-node", snapshot.Nodes[0].Name)
+}
+
+func TestSnapshotStripsManagedFields(t *testing.T) {
+	clientset := fake.NewClientset(newPod("running-pod", "pod-uid", v1.PodRunning))
+	w := startWatcher(t, clientset)
+
+	snapshot, err := w.Snapshot()
+	require.NoError(t, err)
+
+	require.Len(t, snapshot.Pods, 1)
+	assert.Nil(t, snapshot.Pods[0].ManagedFields)
+}
+
+func TestSnapshotIncludesPodDeletedBetweenSnapshots(t *testing.T) {
+	clientset := fake.NewClientset(newNamespace("default"))
+	w := startWatcher(t, clientset)
+
+	// a pod that comes and goes entirely between two snapshots
+	_, err := clientset.CoreV1().Pods("default").Create(
+		context.Background(), newPod("transient-pod", "pod-uid", v1.PodRunning), metav1.CreateOptions{})
+	require.NoError(t, err)
+	waitForCachedPod(t, w, "transient-pod", v1.PodRunning)
+
+	require.NoError(t, clientset.CoreV1().Pods("default").Delete(
+		context.Background(), "transient-pod", metav1.DeleteOptions{}))
+	waitForBuffered(t, w, func() bool { return len(w.deletedPods) == 1 })
+
+	// the snapshot after the deletion still reports the pod...
+	snapshot, err := w.Snapshot()
+	require.NoError(t, err)
+	require.Len(t, snapshot.Pods, 1)
+	assert.Equal(t, "transient-pod", snapshot.Pods[0].Name)
+	assert.Equal(t, "anchore/test:latest", snapshot.Pods[0].Spec.Containers[0].Image)
+
+	// ...but it is only reported once
+	next, err := w.Snapshot()
+	require.NoError(t, err)
+	assert.Empty(t, next.Pods)
+}
+
+func TestSnapshotReportsDeletedPodAsItWasWhileRunning(t *testing.T) {
+	clientset := fake.NewClientset(newNamespace("default"))
+	w := startWatcher(t, clientset)
+
+	pods := clientset.CoreV1().Pods("default")
+	_, err := pods.Create(context.Background(), newPod("transient-pod", "pod-uid", v1.PodRunning), metav1.CreateOptions{})
+	require.NoError(t, err)
+	waitForBuffered(t, w, func() bool { return len(w.lastRunning) == 1 })
+
+	// the pod completes before it is removed
+	_, err = pods.Update(context.Background(), newPod("transient-pod", "pod-uid", v1.PodSucceeded), metav1.UpdateOptions{})
+	require.NoError(t, err)
+	waitForCachedPod(t, w, "transient-pod", v1.PodSucceeded)
+
+	require.NoError(t, pods.Delete(context.Background(), "transient-pod", metav1.DeleteOptions{}))
+	waitForBuffered(t, w, func() bool { return len(w.deletedPods) == 1 })
+
+	// the buffered snapshot is the running one, so ignore-not-running still
+	// reports the container
+	snapshot, err := w.Snapshot()
+	require.NoError(t, err)
+	require.Len(t, snapshot.Pods, 1)
+	assert.Equal(t, v1.PodRunning, snapshot.Pods[0].Status.Phase)
+}
+
+func TestSnapshotBuffersPodThatNeverRan(t *testing.T) {
+	clientset := fake.NewClientset(newNamespace("default"))
+	w := startWatcher(t, clientset)
+
+	pods := clientset.CoreV1().Pods("default")
+	_, err := pods.Create(context.Background(), newPod("pending-pod", "pod-uid", v1.PodPending), metav1.CreateOptions{})
+	require.NoError(t, err)
+	waitForCachedPod(t, w, "pending-pod", v1.PodPending)
+
+	require.NoError(t, pods.Delete(context.Background(), "pending-pod", metav1.DeleteOptions{}))
+	waitForBuffered(t, w, func() bool { return len(w.deletedPods) == 1 })
+
+	// the final state is buffered so that downstream filtering (rather than the
+	// watcher) decides whether to report it
+	snapshot, err := w.Snapshot()
+	require.NoError(t, err)
+	require.Len(t, snapshot.Pods, 1)
+	assert.Equal(t, v1.PodPending, snapshot.Pods[0].Status.Phase)
+	assert.Empty(t, underLock(w, func() map[types.UID]*v1.Pod { return w.lastRunning }))
+}
+
+func TestSnapshotBuffersDeletedNamespacesAndNodes(t *testing.T) {
+	clientset := fake.NewClientset(
+		newNamespace("transient-ns"),
+		newNode("transient-node"),
+	)
+	w := startWatcher(t, clientset)
+
+	require.NoError(t, clientset.CoreV1().Namespaces().Delete(
+		context.Background(), "transient-ns", metav1.DeleteOptions{}))
+	require.NoError(t, clientset.CoreV1().Nodes().Delete(
+		context.Background(), "transient-node", metav1.DeleteOptions{}))
+	waitForBuffered(t, w, func() bool {
+		return len(w.deletedNamespaces) == 1 && len(w.deletedNodes) == 1
+	})
+
+	snapshot, err := w.Snapshot()
+	require.NoError(t, err)
+	require.Len(t, snapshot.Namespaces, 1)
+	assert.Equal(t, "transient-ns", snapshot.Namespaces[0].Name)
+	require.Len(t, snapshot.Nodes, 1)
+	assert.Equal(t, "transient-node", snapshot.Nodes[0].Name)
+
+	next, err := w.Snapshot()
+	require.NoError(t, err)
+	assert.Empty(t, next.Namespaces)
+	assert.Empty(t, next.Nodes)
+}
+
+func TestSnapshotDoesNotDuplicateResourcesStillInTheCache(t *testing.T) {
+	clientset := fake.NewClientset(newNamespace("default"))
+	w := startWatcher(t, clientset)
+
+	_, err := clientset.CoreV1().Pods("default").Create(
+		context.Background(), newPod("recreated-pod", "pod-uid", v1.PodRunning), metav1.CreateOptions{})
+	require.NoError(t, err)
+	waitForCachedPod(t, w, "recreated-pod", v1.PodRunning)
+
+	// a buffered deletion for a UID that is back in the cache (a delete and
+	// recreate the watcher observed out of order) must not be reported twice
+	w.onPodDelete(newPod("recreated-pod", "pod-uid", v1.PodRunning))
+
+	snapshot, err := w.Snapshot()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"recreated-pod"}, podNames(snapshot))
+}
+
+func TestDeleteHandlersUnwrapTombstones(t *testing.T) {
+	clientset := fake.NewClientset()
+	w := startWatcher(t, clientset)
+
+	pod := newPod("tombstoned-pod", "pod-uid", v1.PodRunning)
+	namespace := newNamespace("tombstoned-ns")
+	node := newNode("tombstoned-node")
+
+	w.onPodDelete(cache.DeletedFinalStateUnknown{Key: "default/tombstoned-pod", Obj: pod})
+	w.onNamespaceDelete(cache.DeletedFinalStateUnknown{Key: "tombstoned-ns", Obj: namespace})
+	w.onNodeDelete(cache.DeletedFinalStateUnknown{Key: "tombstoned-node", Obj: node})
+
+	snapshot, err := w.Snapshot()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"tombstoned-pod"}, podNames(snapshot))
+	require.Len(t, snapshot.Namespaces, 1)
+	assert.Equal(t, "tombstoned-ns", snapshot.Namespaces[0].Name)
+	require.Len(t, snapshot.Nodes, 1)
+	assert.Equal(t, "tombstoned-node", snapshot.Nodes[0].Name)
+}
+
+func TestDeleteHandlersIgnoreUnexpectedObjects(t *testing.T) {
+	w, err := New(fake.NewClientset(), Config{CacheSyncTimeout: eventTimeout})
+	require.NoError(t, err)
+
+	w.onPodDelete("not-a-pod")
+	w.onNamespaceDelete(cache.DeletedFinalStateUnknown{Key: "ns", Obj: "not-a-namespace"})
+	w.onNodeDelete(nil)
+	w.onPodUpsert("not-a-pod")
+
+	assert.Empty(t, underLock(w, func() map[string]*v1.Pod { return w.deletedPods }))
+	assert.Empty(t, underLock(w, func() map[string]*v1.Namespace { return w.deletedNamespaces }))
+	assert.Empty(t, underLock(w, func() map[string]*v1.Node { return w.deletedNodes }))
+	assert.Empty(t, underLock(w, func() map[types.UID]*v1.Pod { return w.lastRunning }))
+}
+
+func TestSnapshotKeepsRunningPodsWhoseDeleteEventIsStillInFlight(t *testing.T) {
+	// the pod is absent from the informer cache, standing in for the window
+	// between the informer dropping it and delivering the delete event - those
+	// happen on different goroutines with a queue in between
+	w := startWatcher(t, fake.NewClientset())
+	underLock(w, func() any {
+		w.lastRunning["pod-uid"] = newPod("transient-pod", "pod-uid", v1.PodRunning)
+		return nil
+	})
+
+	// a snapshot taken in that window must not forget how the pod looked while
+	// it was running
+	_, err := w.Snapshot()
+	require.NoError(t, err)
+
+	// the delete event finally lands, carrying the pod as it completed
+	w.onPodDelete(newPod("transient-pod", "pod-uid", v1.PodSucceeded))
+
+	snapshot, err := w.Snapshot()
+	require.NoError(t, err)
+	require.Len(t, snapshot.Pods, 1)
+	assert.Equal(t, v1.PodRunning, snapshot.Pods[0].Status.Phase,
+		"a pod whose delete event arrived after a snapshot should still be reported as it was while running")
+}
+
+func TestNodesAreSkippedWhenForbidden(t *testing.T) {
+	clientset := fake.NewClientset(newNamespace("default"))
+	clientset.PrependReactor("list", "nodes", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, k8sErrors.NewForbidden(schema.GroupResource{Resource: "nodes"}, "", nil)
+	})
+
+	w := startWatcher(t, clientset)
+	assert.False(t, w.NodesEnabled())
+
+	snapshot, err := w.Snapshot()
+	require.NoError(t, err)
+	assert.Empty(t, snapshot.Nodes)
+}
+
+func TestStartFailsWhenCachesCannotSync(t *testing.T) {
+	clientset := fake.NewClientset()
+	// an informer whose LIST is rejected retries forever, so Start has to give
+	// up rather than block the agent indefinitely
+	clientset.PrependReactor("list", "pods", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, k8sErrors.NewForbidden(schema.GroupResource{Resource: "pods"}, "", nil)
+	})
+
+	w, err := New(clientset, Config{CacheSyncTimeout: 100 * time.Millisecond})
+	require.NoError(t, err)
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	assert.Error(t, w.Start(stopCh))
+}
+
+func TestSnapshotPrefersTheLiveNamespaceOverADeletedOneOfTheSameName(t *testing.T) {
+	clientset := fake.NewClientset()
+	w := startWatcher(t, clientset)
+
+	// the namespace is deleted and recreated within one reporting interval, so
+	// the buffered copy and the live copy share a name but not a UID. Pods
+	// reference their namespace by name, so only one of them can be reported.
+	deleted := newNamespace("churn-ns")
+	deleted.UID = "old-ns-uid"
+	w.onNamespaceDelete(deleted)
+
+	recreated := newNamespace("churn-ns")
+	_, err := clientset.CoreV1().Namespaces().Create(context.Background(), recreated, metav1.CreateOptions{})
+	require.NoError(t, err)
+	waitFor(t, func() bool {
+		ns, err := w.nsLister.Get("churn-ns")
+		return err == nil && ns != nil
+	})
+
+	snapshot, err := w.Snapshot()
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"churn-ns"}, namespaceNames(snapshot))
+	require.Len(t, snapshot.Namespaces, 1)
+	assert.Equal(t, recreated.UID, snapshot.Namespaces[0].UID, "the namespace still in the cluster should win")
+}
+
+func TestSnapshotBuffersOneDeletedNamespacePerName(t *testing.T) {
+	w := startWatcher(t, fake.NewClientset())
+
+	// deleted, recreated and deleted again, all between two reports
+	first := newNamespace("churn-ns")
+	first.UID = "first-ns-uid"
+	w.onNamespaceDelete(first)
+
+	second := newNamespace("churn-ns")
+	second.UID = "second-ns-uid"
+	w.onNamespaceDelete(second)
+
+	snapshot, err := w.Snapshot()
+	require.NoError(t, err)
+
+	require.Len(t, snapshot.Namespaces, 1)
+	assert.Equal(t, second.UID, snapshot.Namespaces[0].UID, "the most recently deleted namespace should win")
+}
+
+func TestSnapshotBuffersOneDeletedNodePerName(t *testing.T) {
+	w := startWatcher(t, fake.NewClientset())
+
+	first := newNode("churn-node")
+	first.UID = "first-node-uid"
+	w.onNodeDelete(first)
+
+	second := newNode("churn-node")
+	second.UID = "second-node-uid"
+	w.onNodeDelete(second)
+
+	snapshot, err := w.Snapshot()
+	require.NoError(t, err)
+
+	require.Len(t, snapshot.Nodes, 1)
+	assert.Equal(t, second.UID, snapshot.Nodes[0].UID)
+}
+
+func TestPodsAreWatchedInOneNamespaceWhenOnlyOneIsIncluded(t *testing.T) {
+	included := newPod("included-pod", "included-uid", v1.PodRunning)
+	included.Namespace = "watched"
+	excluded := newPod("excluded-pod", "excluded-uid", v1.PodRunning)
+	excluded.Namespace = "other"
+
+	clientset := fake.NewClientset(included, excluded)
+	w, err := New(clientset, Config{CacheSyncTimeout: eventTimeout, Namespaces: []string{"watched"}})
+	require.NoError(t, err)
+
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	require.NoError(t, w.Start(stopCh))
+
+	snapshot, err := w.Snapshot()
+	require.NoError(t, err)
+
+	// the agent does not cache pods it would only discard when building the
+	// report, which matters on a large cluster
+	assert.Equal(t, []string{"included-pod"}, podNames(snapshot))
+}
+
+func TestPodsAreWatchedClusterWideWhenSeveralNamespacesAreIncluded(t *testing.T) {
+	first := newPod("first-pod", "first-uid", v1.PodRunning)
+	first.Namespace = "a"
+	second := newPod("second-pod", "second-uid", v1.PodRunning)
+	second.Namespace = "b"
+
+	clientset := fake.NewClientset(first, second)
+	w, err := New(clientset, Config{CacheSyncTimeout: eventTimeout, Namespaces: []string{"a", "b"}})
+	require.NoError(t, err)
+
+	stopCh := make(chan struct{})
+	t.Cleanup(func() { close(stopCh) })
+	require.NoError(t, w.Start(stopCh))
+
+	snapshot, err := w.Snapshot()
+	require.NoError(t, err)
+
+	names := podNames(snapshot)
+	sort.Strings(names)
+	assert.Equal(t, []string{"first-pod", "second-pod"}, names)
+}

--- a/test/integration/informer_test.go
+++ b/test/integration/informer_test.go
@@ -1,0 +1,129 @@
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/anchore/k8s-inventory/cmd"
+	"github.com/anchore/k8s-inventory/internal/config"
+	"github.com/anchore/k8s-inventory/pkg"
+	"github.com/anchore/k8s-inventory/pkg/client"
+	"github.com/anchore/k8s-inventory/pkg/watcher"
+)
+
+const (
+	transientPodName  = "k8s-inventory-transient-pod"
+	transientPodImage = "busybox:1.36"
+	// generous enough that a watch event for a resource the api-server has
+	// already deleted has certainly been delivered to the informer
+	informerSettleTime = 5 * time.Second
+)
+
+func transientPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      transientPodName,
+			Namespace: IntegrationTestNamespace,
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers: []corev1.Container{
+				{
+					Name:    "transient",
+					Image:   transientPodImage,
+					Command: []string{"sleep", "300"},
+				},
+			},
+		},
+	}
+}
+
+func containerImageTags(reports pkg.BatchedReports) []string {
+	tags := make([]string, 0)
+	for _, reportsForAccount := range reports {
+		for _, report := range reportsForAccount {
+			for _, container := range report.Containers {
+				tags = append(tags, container.ImageTag)
+			}
+		}
+	}
+	return tags
+}
+
+// TestInformerCapturesTransientPod checks that a pod which is created and
+// deleted in between two inventory reports is still reported, which is the
+// behaviour the polling collection method cannot provide.
+//
+// Assumes that the hello-world helm chart in ./fixtures was installed, which is
+// what creates the integration test namespace.
+func TestInformerCapturesTransientPod(t *testing.T) {
+	cmd.InitAppConfig()
+	cfg := cmd.GetAppConfig()
+	require.Equal(t, config.InventoryCollectionMethodInformer, cfg.InventoryCollection.Method,
+		"the informer collection method should be the default")
+
+	kubeconfig, err := client.GetKubeConfig(cfg)
+	require.NoError(t, err)
+	clientset, err := client.GetClientSet(kubeconfig)
+	require.NoError(t, err)
+
+	w, err := watcher.New(clientset, watcher.Config{
+		RequestTimeout:   30 * time.Second,
+		CacheSyncTimeout: 60 * time.Second,
+	})
+	require.NoError(t, err)
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	require.NoError(t, w.Start(stopCh))
+
+	serverVersion, err := clientset.Discovery().ServerVersion()
+	require.NoError(t, err)
+
+	// the initial report is the equivalent of the first tick after startup
+	snapshot, err := w.Snapshot()
+	require.NoError(t, err)
+	require.NotContains(t, containerImageTags(pkg.GetInventoryReportsFromSnapshot(cfg, snapshot, serverVersion)), transientPodImage)
+
+	pods := clientset.CoreV1().Pods(IntegrationTestNamespace)
+	_, err = pods.Create(context.Background(), transientPod(), metav1.CreateOptions{})
+	require.NoError(t, err)
+	defer func() {
+		_ = pods.Delete(context.Background(), transientPodName, metav1.DeleteOptions{})
+	}()
+
+	// the pod comes...
+	require.Eventually(t, func() bool {
+		pod, err := pods.Get(context.Background(), transientPodName, metav1.GetOptions{})
+		return err == nil && pod.Status.Phase == corev1.PodRunning
+	}, 2*time.Minute, time.Second, "transient pod never reached the Running phase")
+
+	// ...and goes, all without a report being generated
+	gracePeriod := int64(0)
+	require.NoError(t, pods.Delete(context.Background(), transientPodName,
+		metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod}))
+	require.Eventually(t, func() bool {
+		_, err := pods.Get(context.Background(), transientPodName, metav1.GetOptions{})
+		return k8sErrors.IsNotFound(err)
+	}, time.Minute, time.Second, "transient pod was never removed")
+	time.Sleep(informerSettleTime)
+
+	// the next report still contains the container that briefly existed
+	snapshot, err = w.Snapshot()
+	require.NoError(t, err)
+	assert.Contains(t, containerImageTags(pkg.GetInventoryReportsFromSnapshot(cfg, snapshot, serverVersion)), transientPodImage,
+		"the transient pod's container was not reported")
+
+	// and the report after that does not, as the pod is long gone
+	snapshot, err = w.Snapshot()
+	require.NoError(t, err)
+	assert.NotContains(t, containerImageTags(pkg.GetInventoryReportsFromSnapshot(cfg, snapshot, serverVersion)), transientPodImage,
+		"the transient pod's container was reported more than once")
+}


### PR DESCRIPTION
Periodic inventory collection listed every namespace, pod and node from
the api-server on each polling interval, so pods and containers that were
created and deleted in between two reports were never reported at all. On
a large cluster that per-interval listing is also a significant load on
the api-server, with LIST payloads big enough to time out.

Add a watcher that keeps informer caches for pods, namespaces and nodes up
to date from the Kubernetes event stream, and buffers anything deleted
since the last report so that short lived pods (and the containers within
them) are included in the next one. A deleted pod is reported as it was
while it was last running, so the ignore-not-running behaviour is
unchanged. Namespaces and nodes are buffered on deletion too, so that
buffered pods keep the parents reporter.Normalize requires. They are
buffered by name rather than UID, because pods reference them by name, and
anything still in the informer cache wins over a buffered deletion, so a
namespace deleted and recreated within one interval is reported once
rather than duplicating every pod and container in it.

The informers are started in the background: the agent polls for inventory
while the caches fill and switches over once they have synced, so the
reporting cadence is never held up by the initial cluster-wide listing. If
they cannot be started at all the agent carries on polling and retries
after a delay that doubles from one minute up to one hour, so a cluster it
is not permitted to watch settles into steady polling rather than
re-listing on every interval. The deadline for that first listing is
inventory-collection.informer.cache-sync-timeout-seconds, kept separate
from kubernetes.request-timeout-seconds, which bounds a single request and
where zero means "no limit" rather than "fail immediately".

The pod informer drops managedFields before caching, since they are never
reported and are a large part of the footprint of a cluster wide cache,
and it is scoped to a single namespace when namespace-selectors.include
names exactly one. Watching requires the watch verb on pods, namespaces
and nodes as well as get and list; the Helm chart already grants these.
Being allowed to list but not watch leaves the agent looking healthy while
capturing nothing transient, which it cannot currently detect, so that is
documented alongside the permission requirement. Not being permitted to
read nodes at all is tolerated, as it is when polling.

This is now the default collection method. The previous behaviour is
available with inventory-collection.method: poll, and adhoc mode continues
to poll. The report payload is unchanged, so no Enterprise side change is
needed.

ENTERPRISE-3875
